### PR TITLE
Add an EmailAddress type

### DIFF
--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -14,6 +14,7 @@ import play.api.libs.mailer.AttachmentFile
 import repositories.{AuthTokenRepository, UserRepository}
 import services.MailerService
 import utils.silhouette.auth.{AuthEnv, UserService}
+import utils.EmailAddress
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -87,7 +88,7 @@ class AuthController @Inject()(
   private def sendResetPasswordMail(user: User, url: String) = {
     logger.debug(s"email ${user.email.get}")
     Future(mailerService.sendEmail(
-      from = configuration.get[String]("play.mail.from"),
+      from = EmailAddress(configuration.get[String]("play.mail.from")),
       recipients = user.email.get)(
       subject = "Votre mot de passe SignalConso",
       bodyHtml = views.html.mails.resetPassword(user, url).toString,

--- a/app/controllers/ReportListController.scala
+++ b/app/controllers/ReportListController.scala
@@ -143,7 +143,7 @@ class ReportListController @Inject()(reportRepository: ReportRepository,
       ),
       ReportColumn(
         "Email de l'établissement", centerAlignmentColumn,
-        (report, _, companyUser) => companyUser.filter(_ => report.isEligible).flatMap(_.email).getOrElse(""),
+        (report, _, companyUser) => companyUser.filter(_ => report.isEligible).flatMap(_.email).map(_.value).getOrElse(""),
         available=request.identity.userRole == UserRoles.Admin
       ),
       ReportColumn(
@@ -209,7 +209,7 @@ class ReportListController @Inject()(reportRepository: ReportRepository,
       ),
       ReportColumn(
         "Email", leftAlignmentColumn,
-        (report, _, _) => report.email,
+        (report, _, _) => report.email.value,
         available = List(UserRoles.DGCCRF, UserRoles.Admin) contains request.identity.userRole
       ),
       ReportColumn(

--- a/app/models/Report.scala
+++ b/app/models/Report.scala
@@ -7,6 +7,7 @@ import com.github.tminglei.slickpg.composite.Struct
 import play.api.libs.json.{Json, OFormat, Writes}
 import utils.Constants.ReportStatus._
 import utils.Constants.Departments
+import utils.EmailAddress
 
 case class Report(
                    id: Option[UUID],
@@ -21,7 +22,7 @@ case class Report(
                    creationDate: Option[OffsetDateTime],
                    firstName: String,
                    lastName: String,
-                   email: String,
+                   email: EmailAddress,
                    contactAgreement: Boolean,
                    files: List[ReportFile],
                    status: Option[ReportStatusValue]

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -7,13 +7,14 @@ import com.mohiva.play.silhouette.api.Identity
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import utils.EnumUtils
+import utils.EmailAddress
 
 case class User (
                  id: UUID,
                  login: String,
                  password: String,
                  activationKey: Option[String],
-                 email: Option[String],
+                 email: Option[EmailAddress],
                  firstName: Option[String],
                  lastName: Option[String],
                  userRole: UserRole
@@ -37,7 +38,7 @@ object User {
       (JsPath \ "login").read[String] and
       (JsPath \ "password").read[String] and
       (JsPath \ "activationKey").readNullable[String] and
-      (JsPath \ "email").readNullable[String] and
+      (JsPath \ "email").readNullable[EmailAddress] and
       (JsPath \ "firstName").readNullable[String] and
       (JsPath \ "lastName").readNullable[String] and
       ((JsPath \ "role").read[String]).map(UserRoles.withName(_))

--- a/app/repositories/ReportRepository.scala
+++ b/app/repositories/ReportRepository.scala
@@ -12,6 +12,7 @@ import utils.Constants.ActionEvent.MODIFICATION_COMMERCANT
 import utils.Constants.ReportStatus
 import utils.Constants.ReportStatus.ReportStatusValue
 import utils.DateUtils
+import utils.EmailAddress
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -50,13 +51,13 @@ class ReportRepository @Inject()(dbConfigProvider: DatabaseConfigProvider, userR
     def creationDate= column[OffsetDateTime]("date_creation")
     def firstName = column[String]("prenom")
     def lastName = column[String]("nom")
-    def email = column[String]("email")
+    def email = column[EmailAddress]("email")
     def contactAgreement = column[Boolean]("accord_contact")
     def status = column[Option[String]]("status")
 
     def company = foreignKey("COMPANY_FK", companyId, companyRepository.companyTableQuery)(_.id.?, onUpdate=ForeignKeyAction.Restrict, onDelete=ForeignKeyAction.Cascade)
 
-    type ReportData = (UUID, String, List[String], List[String], Option[UUID], String, String, Option[String], Option[String], OffsetDateTime, String, String, String, Boolean, Option[String])
+    type ReportData = (UUID, String, List[String], List[String], Option[UUID], String, String, Option[String], Option[String], OffsetDateTime, String, String, EmailAddress, Boolean, Option[String])
 
     def constructReport: ReportData => Report = {
       case (id, category, subcategories, details, companyId, companyName, companyAddress, companyPostalCode, companySiret, creationDate, firstName, lastName, email, contactAgreement, status) =>
@@ -255,7 +256,7 @@ class ReportRepository @Inject()(dbConfigProvider: DatabaseConfigProvider, userR
             case table => table.companyPostalCode.map(cp => cp.substring(0, 2).inSet(filter.departments)).getOrElse(false)
           }
           .filterOpt(filter.email) {
-            case(table, email) => table.email === email
+            case(table, email) => table.email === EmailAddress(email)
           }
           .filterOpt(filter.siret) {
             case(table, siret) => table.companySiret === siret

--- a/app/repositories/SubscriptionRepository.scala
+++ b/app/repositories/SubscriptionRepository.scala
@@ -3,9 +3,10 @@ package repositories
 import java.util.UUID
 
 import javax.inject.{Inject, Singleton}
-import models.Subscription
+import models._
 import play.api.db.slick.DatabaseConfigProvider
 import slick.jdbc.JdbcProfile
+import utils.EmailAddress
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -65,15 +66,14 @@ class SubscriptionRepository @Inject()(dbConfigProvider: DatabaseConfigProvider,
       .map(_ => subscription)
   }
 
-  def listSubscribeUserMailsForDepartment(code: String) = db
+  def listSubscribeUserMailsForDepartment(code: String): Future[List[EmailAddress]] = db
     .run(
       subscriptionTableQuery
         .filter(subscription => code.bind === subscription.values.any)
-        .joinLeft(userTableQuery).on(_.userId === _.id)
-        .map(_._2)
+        .join(userTableQuery).on(_.userId === _.id)
+        .map(_._2.email)
         .to[List]
         .result
-        .map(result => result.flatMap(_.flatMap(_.email)))
-    )
+    ).map(_.flatten)
 }
 

--- a/app/repositories/UserRepository.scala
+++ b/app/repositories/UserRepository.scala
@@ -7,6 +7,7 @@ import javax.inject.{Inject, Singleton}
 import models._
 import play.api.db.slick.DatabaseConfigProvider
 import slick.jdbc.JdbcProfile
+import utils.EmailAddress
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -31,12 +32,12 @@ class UserRepository @Inject()(dbConfigProvider: DatabaseConfigProvider,
     def login = column[String]("login")
     def password = column[String]("password")
     def activationKey = column[Option[String]]("activation_key")
-    def email = column[Option[String]]("email")
+    def email = column[Option[EmailAddress]]("email")
     def firstName = column[Option[String]]("firstname")
     def lastName = column[Option[String]]("lastname")
     def role = column[String]("role")
 
-    type UserData = (UUID, String, String, Option[String], Option[String], Option[String], Option[String], String)
+    type UserData = (UUID, String, String, Option[String], Option[EmailAddress], Option[String], Option[String], String)
 
     def constructUser: UserData => User = {
       case (id, login, password, activationKey, email, firstName, lastName, role) => User(id, login, password, activationKey, email, firstName, lastName, UserRoles.withName(role))
@@ -93,7 +94,7 @@ class UserRepository @Inject()(dbConfigProvider: DatabaseConfigProvider,
   def delete(userId: UUID): Future[Int] = db
     .run(userTableQuery.filter(_.id === userId).delete)
 
-  def delete(email: String): Future[Int] = db
+  def delete(email: EmailAddress): Future[Int] = db
     .run(userTableQuery.filter(_.email === email).delete)
 
   def findByLogin(login: String): Future[Option[User]] =
@@ -101,7 +102,7 @@ class UserRepository @Inject()(dbConfigProvider: DatabaseConfigProvider,
     .run(userTableQuery
     .filter(u =>
       if (login.contains("@"))
-        (u.email === login).getOrElse(false)
+        (u.email === EmailAddress(login)).getOrElse(false)
       else
         (u.login === login)
       ).to[List].result.headOption)

--- a/app/services/MailerService.scala
+++ b/app/services/MailerService.scala
@@ -4,14 +4,15 @@ import akka.actor.ActorSystem
 import javax.inject.Inject
 import play.api.Logger
 import play.api.libs.mailer._
+import utils.EmailAddress
+
 
 class MailerService @Inject() (mailerClient: MailerClient, system: ActorSystem) {
 
   val logger: Logger = Logger(this.getClass)
 
-  def sendEmail(from: String, recipients: String*)(subject: String, bodyHtml: String, attachments: Seq[Attachment] = Seq.empty) = {
-    mailerClient.send(Email(subject, from, recipients, bodyHtml = Some(bodyHtml), attachments = attachments))
+  def sendEmail(from: EmailAddress, recipients: EmailAddress*)(subject: String, bodyHtml: String, attachments: Seq[Attachment] = Seq.empty) = {
+    mailerClient.send(Email(subject, from.value, recipients.map(_.value), bodyHtml = Some(bodyHtml), attachments = attachments))
   }
-
 }
 

--- a/app/utils/EmailAddress.scala
+++ b/app/utils/EmailAddress.scala
@@ -1,0 +1,22 @@
+package utils
+
+import play.api.libs.json._
+import repositories.PostgresProfile.api._
+
+case class EmailAddress(value: String)
+
+object EmailAddress {
+  def apply(value: String) = new EmailAddress(value.trim.toLowerCase)
+  implicit val EmailColumnType = MappedColumnType.base[EmailAddress, String](
+    _.value,
+    EmailAddress(_)
+  )
+  implicit val emailWrites = new Writes[EmailAddress] {
+    def writes(o: EmailAddress): JsValue = {
+      JsString(o.value)
+    }
+  }
+  implicit val emailReads = new Reads[EmailAddress] {
+    def reads(json: JsValue): JsResult[EmailAddress] = json.validate[String].map(EmailAddress(_))
+  }
+}

--- a/app/utils/silhouette/auth/PasswordInfoDAO.scala
+++ b/app/utils/silhouette/auth/PasswordInfoDAO.scala
@@ -7,6 +7,7 @@ import javax.inject.Inject
 import play.api.Logger
 import repositories.UserRepository
 import utils.silhouette.Implicits._
+import utils.EmailAddress
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -26,7 +27,7 @@ class PasswordInfoDAO @Inject() (userRepository: UserRepository) extends Delegab
     }
   }
 
-  def remove(loginInfo: LoginInfo): Future[Unit] = userRepository.delete(loginInfo).map(_ => ())
+  def remove(loginInfo: LoginInfo): Future[Unit] = userRepository.delete(EmailAddress(loginInfo)).map(_ => ())    // FIXME: Is it used ?
 
   def save(loginInfo: LoginInfo, authInfo: PasswordInfo): Future[PasswordInfo] =
     find(loginInfo).flatMap {

--- a/test/controllers/AccountControllerSpec.scala
+++ b/test/controllers/AccountControllerSpec.scala
@@ -19,6 +19,7 @@ import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test._
 import utils.silhouette.auth.AuthEnv
+import utils.EmailAddress
 
 class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification with Results with Mockito {
 
@@ -52,7 +53,7 @@ class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification wit
 
   trait Context extends Scope {
 
-    val identity = User(UUID.randomUUID(),"test@signalconso.beta.gouv.fr", "password", None, Some("Prénom"), Some("Nom"), Some("email"), UserRoles.Admin)
+    val identity = User(UUID.randomUUID(), "test@signalconso.beta.gouv.fr", "password", None, Some(EmailAddress("toto@example.com")), Some("Prénom"), Some("Nom"), UserRoles.Admin)
     val identLoginInfo = LoginInfo(CredentialsProvider.ID, identity.login)
     implicit val env: Environment[AuthEnv] = new FakeEnvironment[AuthEnv](Seq(identLoginInfo -> identity))
 

--- a/test/controllers/ReportControllerSpec.scala
+++ b/test/controllers/ReportControllerSpec.scala
@@ -30,6 +30,7 @@ import utils.Constants.ReportStatus._
 import utils.Constants.{ActionEvent, Departments, EventType, ReportStatus}
 import utils.silhouette.api.APIKeyEnv
 import utils.silhouette.auth.AuthEnv
+import utils.EmailAddress
 
 import scala.concurrent.Future
 
@@ -117,7 +118,7 @@ class ReportControllerSpec(implicit ee: ExecutionEnv) extends Specification with
           val reportsList = List(
             Report(
               reportId, "foo", List("bar"), List(), None, "myCompany", "18 rue des Champs",
-              None, Some("00000000000000"), Some(OffsetDateTime.now()), "John", "Doe", "jdoe@example.com",
+              None, Some("00000000000000"), Some(OffsetDateTime.now()), "John", "Doe", EmailAddress("jdoe@example.com"),
               true, List(), None
             )
           )
@@ -146,9 +147,9 @@ class ReportControllerSpec(implicit ee: ExecutionEnv) extends Specification with
 
   trait Context extends Scope {
 
-    val adminIdentity = User(UUID.randomUUID(),"admin@signalconso.beta.gouv.fr", "password", None, Some("Prénom"), Some("Nom"), Some("admin@signalconso.beta.gouv.fr"), UserRoles.Admin)
+    val adminIdentity = User(UUID.randomUUID(),"admin@signalconso.beta.gouv.fr", "password", None, Some(EmailAddress("admin@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"), UserRoles.Admin)
     val adminLoginInfo = LoginInfo(CredentialsProvider.ID, adminIdentity.login)
-    val proIdentity = User(UUID.randomUUID(),"00000000000000", "password", None, Some("Prénom"), Some("Nom"), Some("pro@signalconso.beta.gouv.fr"), UserRoles.Pro)
+    val proIdentity = User(UUID.randomUUID(),"00000000000000", "password", None, Some(EmailAddress("pro@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"), UserRoles.Pro)
     val proLoginInfo = LoginInfo(CredentialsProvider.ID, proIdentity.login)
 
     implicit val env: Environment[AuthEnv] = new FakeEnvironment[AuthEnv](Seq(adminLoginInfo -> adminIdentity, proLoginInfo -> proIdentity))

--- a/test/controllers/report/GetReportSpec.scala
+++ b/test/controllers/report/GetReportSpec.scala
@@ -29,6 +29,7 @@ import utils.Constants.ActionEvent.ActionEventValue
 import utils.Constants.ReportStatus._
 import utils.Constants.{ActionEvent, Departments, EventType, ReportStatus}
 import utils.silhouette.auth.AuthEnv
+import utils.EmailAddress
 
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -129,10 +130,10 @@ trait GetReportSpec extends Spec with GetReportContext {
     someResult must beSome and contentAsJson(Future(someResult.get)) === Json.toJson(report)
   }
 
-  def mailMustHaveBeenSent(recipient: String, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
+  def mailMustHaveBeenSent(recipient: EmailAddress, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
     there was one(application.injector.instanceOf[MailerService])
       .sendEmail(
-        application.configuration.get[String]("play.mail.from"),
+        EmailAddress(application.configuration.get[String]("play.mail.from")),
         recipient
       )(
         subject,
@@ -143,7 +144,7 @@ trait GetReportSpec extends Spec with GetReportContext {
 
 
   def mailMustNotHaveBeenSent() = {
-    there was no(application.injector.instanceOf[MailerService]).sendEmail(anyString, anyString)(anyString, anyString, any)
+    there was no(application.injector.instanceOf[MailerService]).sendEmail(EmailAddress(anyString), EmailAddress(anyString))(anyString, anyString, any)
   }
 
   def reportMustHaveBeenUpdatedWithStatus(status: ReportStatusValue) = {
@@ -182,28 +183,28 @@ trait GetReportContext extends Mockito {
   val neverRequestedReportUUID = UUID.randomUUID();
   val neverRequestedReport = Report(
     Some(neverRequestedReportUUID), "category", List("subcategory"), List(), None, "companyName", "companyAddress", Some(Departments.AUTHORIZED(0)), Some(siretForConcernedPro), Some(OffsetDateTime.now()),
-    "firstName", "lastName", "email", true, List(), None
+    "firstName", "lastName", EmailAddress("email"), true, List(), None
   )
 
   val neverRequestedFinalReportUUID = UUID.randomUUID();
   val neverRequestedFinalReport = Report(
     Some(neverRequestedFinalReportUUID), "category", List("subcategory"), List(), None, "companyName", "companyAddress", Some(Departments.AUTHORIZED(0)), Some(siretForConcernedPro), Some(OffsetDateTime.now()),
-    "firstName", "lastName", "email", true, List(), Some(SIGNALEMENT_CONSULTE_IGNORE)
+    "firstName", "lastName", EmailAddress("email"), true, List(), Some(SIGNALEMENT_CONSULTE_IGNORE)
   )
 
   val alreadyRequestedReportUUID = UUID.randomUUID();
   val alreadyRequestedReport = Report(
     Some(alreadyRequestedReportUUID), "category", List("subcategory"), List(), None, "companyName", "companyAddress", Some(Departments.AUTHORIZED(0)), Some(siretForConcernedPro), Some(OffsetDateTime.now()),
-    "firstName", "lastName", "email", true, List(), None
+    "firstName", "lastName", EmailAddress("email"), true, List(), None
   )
 
-  val adminUser = User(UUID.randomUUID(), "admin@signalconso.beta.gouv.fr", "password", None, Some("Prénom"), Some("Nom"), Some("admin@signalconso.beta.gouv.fr"), UserRoles.Admin)
+  val adminUser = User(UUID.randomUUID(), "admin@signalconso.beta.gouv.fr", "password", None, Some(EmailAddress("admin@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"), UserRoles.Admin)
   val adminLoginInfo = LoginInfo(CredentialsProvider.ID, adminUser.login)
 
-  val concernedProUser = User(UUID.randomUUID(), siretForConcernedPro, "password", None, Some("Prénom"), Some("Nom"), Some("pro@signalconso.beta.gouv.fr"), UserRoles.Pro)
+  val concernedProUser = User(UUID.randomUUID(), siretForConcernedPro, "password", None, Some(EmailAddress("pro@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"), UserRoles.Pro)
   val concernedProLoginInfo = LoginInfo(CredentialsProvider.ID, concernedProUser.login)
 
-  val notConcernedProUser = User(UUID.randomUUID(), siretForNotConcernedPro, "password", None, Some("Prénom"), Some("Nom"), Some("pro@signalconso.beta.gouv.fr"), UserRoles.Pro)
+  val notConcernedProUser = User(UUID.randomUUID(), siretForNotConcernedPro, "password", None, Some(EmailAddress("pro@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"), UserRoles.Pro)
   val notConcernedProLoginInfo = LoginInfo(CredentialsProvider.ID, notConcernedProUser.login)
 
   implicit val env: Environment[AuthEnv] = new FakeEnvironment[AuthEnv](Seq(adminLoginInfo -> adminUser, concernedProLoginInfo -> concernedProUser, notConcernedProLoginInfo -> notConcernedProUser))

--- a/test/controllers/report/ReportResponseSpec.scala
+++ b/test/controllers/report/ReportResponseSpec.scala
@@ -24,6 +24,7 @@ import utils.Constants.ActionEvent.ActionEventValue
 import utils.Constants.ReportStatus.ReportStatusValue
 import utils.Constants.{ActionEvent, Departments, ReportStatus}
 import utils.silhouette.auth.AuthEnv
+import utils.EmailAddress
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -95,7 +96,7 @@ abstract class ReportResponseSpec(implicit ee: ExecutionEnv) extends Specificati
   lazy val userRepository = app.injector.instanceOf[UserRepository]
   lazy val eventRepository = app.injector.instanceOf[EventRepository]
 
-  val contactEmail = "contact@signalconso.beta.gouv.fr"
+  val contactEmail = EmailAddress("contact@signalconso.beta.gouv.fr")
 
   val siretForConcernedPro = "000000000000000"
   val siretForNotConcernedPro = "11111111111111"
@@ -103,15 +104,15 @@ abstract class ReportResponseSpec(implicit ee: ExecutionEnv) extends Specificati
   val reportUUID = UUID.randomUUID()
   val reportFixture = Report(
     Some(reportUUID), "category", List("subcategory"), List(), None, "companyName", "companyAddress", Some(Departments.AUTHORIZED(0)), Some(siretForConcernedPro), Some(OffsetDateTime.now()),
-    "firstName", "lastName", "email", true, List(), None
+    "firstName", "lastName", EmailAddress("email"), true, List(), None
   )
 
   var report = reportFixture
 
-  val concernedProUser = User(UUID.randomUUID(), siretForConcernedPro, "password", None, Some("Prénom"), Some("Nom"), Some("pro@signalconso.beta.gouv.fr"), UserRoles.Pro)
+  val concernedProUser = User(UUID.randomUUID(), siretForConcernedPro, "password", None, Some(EmailAddress("pro@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"), UserRoles.Pro)
   val concernedProLoginInfo = LoginInfo(CredentialsProvider.ID, concernedProUser.login)
 
-  val notConcernedProUser = User(UUID.randomUUID(), siretForNotConcernedPro, "password", None, Some("Prénom"), Some("Nom"), Some("pro@signalconso.beta.gouv.fr"), UserRoles.Pro)
+  val notConcernedProUser = User(UUID.randomUUID(), siretForNotConcernedPro, "password", None, Some(EmailAddress("pro@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"), UserRoles.Pro)
   val notConcernedProLoginInfo = LoginInfo(CredentialsProvider.ID, notConcernedProUser.login)
 
   var someLoginInfo: Option[LoginInfo] = None
@@ -160,10 +161,10 @@ abstract class ReportResponseSpec(implicit ee: ExecutionEnv) extends Specificati
     someResult must beSome and someResult.get.header.status === status
   }
 
-  def mailMustHaveBeenSent(recipient: String, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
+  def mailMustHaveBeenSent(recipient: EmailAddress, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
     there was one(app.injector.instanceOf[MailerService])
       .sendEmail(
-        app.configuration.get[String]("play.mail.from"),
+        EmailAddress(app.configuration.get[String]("play.mail.from")),
         recipient
       )(
         subject,

--- a/test/repositories/UserRepositorySpec.scala
+++ b/test/repositories/UserRepositorySpec.scala
@@ -8,6 +8,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 
 import utils.AppSpec
+import utils.EmailAddress
 
 import models._
 import repositories._
@@ -17,7 +18,7 @@ class UserRepositorySpec(implicit ee: ExecutionEnv) extends Specification with A
   lazy val userRepository = injector.instanceOf[UserRepository]
   val userToto = User(
                   UUID.randomUUID(), "toto", "password",
-                  None, Some("Prénom"), Some("Nom"), Some("pro@signalconso.beta.gouv.fr"),
+                  None, Some(EmailAddress("pro@signalconso.beta.gouv.fr")), Some("Prénom"), Some("Nom"),
                   UserRoles.Pro
                 )
 

--- a/test/tasks/OnGoingReportForUserWithEmailReminderTaskSpec.scala
+++ b/test/tasks/OnGoingReportForUserWithEmailReminderTaskSpec.scala
@@ -18,6 +18,7 @@ import utils.Constants.{ActionEvent, ReportStatus}
 import utils.Constants.ActionEvent.{ActionEventValue, CONTACT_EMAIL, RELANCE}
 import utils.Constants.EventType.PRO
 import utils.Constants.ReportStatus.{ReportStatusValue, TRAITEMENT_EN_COURS}
+import utils.EmailAddress
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -108,13 +109,13 @@ abstract class OnGoingReportForUserWithEmailReminderTaskSpec(implicit ee: Execut
 
   val runningDateTime = LocalDate.of(2019, 9, 26).atStartOfDay()
 
-  val userWithEmail = User(UUID.randomUUID(), "22222222222222", "", None, Some("email"), None, Some("test"), Pro)
+  val userWithEmail = User(UUID.randomUUID(), "22222222222222", "", None, Some(EmailAddress("email")), None, Some("test"), Pro)
 
   val reportUUID = UUID.randomUUID()
 
   val onGoingReport = Report(Some(reportUUID), "test", List.empty, List("détails test"), None, "company1", "addresse" + UUID.randomUUID().toString, None,
     Some(userWithEmail.login),
-    Some(OffsetDateTime.of(2019, 9, 26, 0, 0, 0, 0, ZoneOffset.UTC)), "r1", "nom 1", "email 1", true, List.empty,
+    Some(OffsetDateTime.of(2019, 9, 26, 0, 0, 0, 0, ZoneOffset.UTC)), "r1", "nom 1", EmailAddress("email 1"), true, List.empty,
     Some(TRAITEMENT_EN_COURS))
   val outOfTimeContactByMailEvent = Event(Some(UUID.randomUUID()), Some(reportUUID),
     Some(userWithEmail.id),
@@ -136,10 +137,10 @@ abstract class OnGoingReportForUserWithEmailReminderTaskSpec(implicit ee: Execut
 
 
 
-  def mailMustHaveBeenSent(recipient: String, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
+  def mailMustHaveBeenSent(recipient: EmailAddress, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
     there was one(app.injector.instanceOf[MailerService])
       .sendEmail(
-        app.configuration.get[String]("play.mail.from"),
+        EmailAddress(app.configuration.get[String]("play.mail.from")),
         recipient
       )(
         subject,
@@ -149,7 +150,7 @@ abstract class OnGoingReportForUserWithEmailReminderTaskSpec(implicit ee: Execut
   }
 
   def mailMustNotHaveBeenSent() = {
-    there was no(app.injector.instanceOf[MailerService]).sendEmail(anyString, anyString)(anyString, anyString, any)
+    there was no(app.injector.instanceOf[MailerService]).sendEmail(EmailAddress(anyString), EmailAddress(anyString))(anyString, anyString, any)
   }
 
   def eventMustHaveBeenCreatedWithAction(reportUUID: UUID, action: ActionEventValue) = {

--- a/test/tasks/OnGoingReportForUserWithoutEmailReminderTaskSpec.scala
+++ b/test/tasks/OnGoingReportForUserWithoutEmailReminderTaskSpec.scala
@@ -18,6 +18,7 @@ import utils.Constants.{ActionEvent, ReportStatus}
 import utils.Constants.ActionEvent.{ActionEventValue, CONTACT_COURRIER, RELANCE}
 import utils.Constants.EventType.PRO
 import utils.Constants.ReportStatus.{ReportStatusValue, TRAITEMENT_EN_COURS}
+import utils.EmailAddress
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -83,7 +84,7 @@ abstract class OnGoingReportForUserWithoutEmailReminderTaskSpec(implicit ee: Exe
 
   val onGoingReport = Report(Some(reportUUID), "test", List.empty, List("détails test"), None, "company1", "addresse" + UUID.randomUUID().toString, None,
     Some(userWithoutEmail.login),
-    Some(OffsetDateTime.of(2019, 9, 26, 0, 0, 0, 0, ZoneOffset.UTC)), "r1", "nom 1", "email 1", true, List.empty,
+    Some(OffsetDateTime.of(2019, 9, 26, 0, 0, 0, 0, ZoneOffset.UTC)), "r1", "nom 1", EmailAddress("email 1"), true, List.empty,
     Some(TRAITEMENT_EN_COURS))
   val outOfTimeContactByPostEvent = Event(Some(UUID.randomUUID() ), Some(reportUUID),
     Some(userWithoutEmail.id),
@@ -102,10 +103,10 @@ abstract class OnGoingReportForUserWithoutEmailReminderTaskSpec(implicit ee: Exe
     Some(OffsetDateTime.of(2019, 9, 8, 0, 0, 0, 0, ZoneOffset.UTC)), PRO,
     RELANCE, stringToDetailsJsValue("test"))
 
-  def mailMustHaveBeenSent(recipient: String, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
+  def mailMustHaveBeenSent(recipient: EmailAddress, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
     there was one(app.injector.instanceOf[MailerService])
       .sendEmail(
-        app.configuration.get[String]("play.mail.from"),
+        EmailAddress(app.configuration.get[String]("play.mail.from")),
         recipient
       )(
         subject,
@@ -115,7 +116,7 @@ abstract class OnGoingReportForUserWithoutEmailReminderTaskSpec(implicit ee: Exe
   }
 
   def mailMustNotHaveBeenSent() = {
-    there was no(app.injector.instanceOf[MailerService]).sendEmail(anyString, anyString)(anyString, anyString, any)
+    there was no(app.injector.instanceOf[MailerService]).sendEmail(EmailAddress(anyString), EmailAddress(anyString))(anyString, anyString, any)
   }
 
   def eventMustHaveBeenCreatedWithAction(reportUUID: UUID, action: ActionEventValue) = {

--- a/test/tasks/TransmittedReportReminderTaskSpec.scala
+++ b/test/tasks/TransmittedReportReminderTaskSpec.scala
@@ -18,6 +18,7 @@ import utils.Constants.ActionEvent.{ActionEventValue, CONTACT_EMAIL, ENVOI_SIGNA
 import utils.Constants.EventType.PRO
 import utils.Constants.ReportStatus.{SIGNALEMENT_TRANSMIS, ReportStatusValue, TRAITEMENT_EN_COURS}
 import utils.Constants.{ActionEvent, ReportStatus}
+import utils.EmailAddress
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -108,13 +109,13 @@ abstract class TransmittedReportReminderTaskSpec(implicit ee: ExecutionEnv) exte
 
   val runningDateTime = LocalDate.of(2019, 9, 26).atStartOfDay()
 
-  val userWithEmail = User(UUID.randomUUID(), "22222222222222", "", None, Some("email"), None, Some("test"), Pro)
+  val userWithEmail = User(UUID.randomUUID(), "22222222222222", "", None, Some(EmailAddress("email")), None, Some("test"), Pro)
 
   val reportUUID = UUID.randomUUID()
 
   val transmittedReport = Report(Some(reportUUID), "test", List.empty, List("détails test"), None, "company1", "addresse" + UUID.randomUUID().toString, None,
     Some(userWithEmail.login),
-    Some(OffsetDateTime.of(2019, 9, 26, 0, 0, 0, 0, ZoneOffset.UTC)), "r1", "nom 1", "email 1", true, List.empty,
+    Some(OffsetDateTime.of(2019, 9, 26, 0, 0, 0, 0, ZoneOffset.UTC)), "r1", "nom 1", EmailAddress("email 1"), true, List.empty,
     Some(SIGNALEMENT_TRANSMIS))
   val outOfTimeReportTransmittedEvent = Event(Some(UUID.randomUUID()), Some(reportUUID),
     Some(userWithEmail.id),
@@ -136,10 +137,10 @@ abstract class TransmittedReportReminderTaskSpec(implicit ee: ExecutionEnv) exte
 
 
 
-  def mailMustHaveBeenSent(recipient: String, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
+  def mailMustHaveBeenSent(recipient: EmailAddress, subject: String, bodyHtml: String, attachments: Seq[Attachment] = null) = {
     there was one(app.injector.instanceOf[MailerService])
       .sendEmail(
-        app.configuration.get[String]("play.mail.from"),
+        EmailAddress(app.configuration.get[String]("play.mail.from")),
         recipient
       )(
         subject,
@@ -149,7 +150,7 @@ abstract class TransmittedReportReminderTaskSpec(implicit ee: ExecutionEnv) exte
   }
 
   def mailMustNotHaveBeenSent() = {
-    there was no(app.injector.instanceOf[MailerService]).sendEmail(anyString, anyString)(anyString, anyString, any)
+    there was no(app.injector.instanceOf[MailerService]).sendEmail(EmailAddress(anyString), EmailAddress(anyString))(anyString, anyString, any)
   }
 
   def eventMustHaveBeenCreatedWithAction(reportUUID: UUID, action: ActionEventValue) = {


### PR DESCRIPTION
Pour l'instant, ce type permet de s'assurer que tout email reçu par le système (passé via un JSON, un paramètre de config ou lu depuis la BDD) est traité de façon normalisée (trim et lowercase).

À l'avenir, on pourrait générer des erreurs lorsque des emails non valides sont reçus.

PS: Très pénible de refacto les tests, car il y a beaucoup de duplication de code. Pour la suite je pense que des méthodes standard pour générer des fixtures seraient les bienvenues (à discuter).