### PR TITLE
Preserve original filename as a suffix when uploading to S3

### DIFF
--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -124,7 +124,7 @@ class ReportController @Inject()(reportOrchestrator: ReportOrchestrator,
 
   private def handleFilePartAwsUploadResult: Multipart.FilePartHandler[MultipartUploadResult] = {
     case FileInfo(partName, filename, contentType, dispositionType) =>
-      val accumulator = Accumulator(s3Service.upload(BucketName, UUID.randomUUID.toString))
+      val accumulator = Accumulator(s3Service.upload(BucketName, s"${UUID.randomUUID.toString}_${filename}"))
 
       accumulator map { multipartUploadResult =>
         FilePart(partName, filename, contentType, multipartUploadResult)


### PR DESCRIPTION
FYI, here is what the policy looks like in preprod:
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Deny",
      "Principal": "*",
      "Action": "s3:putObject",
      "NotResource": [
        "arn:aws:s3:::bucket-report/*.jpg",
        "arn:aws:s3:::bucket-report/*.JPG",
        "arn:aws:s3:::bucket-report/*.jpeg",
        "arn:aws:s3:::bucket-report/*.JPEG",
        "arn:aws:s3:::bucket-report/*.pdf",
        "arn:aws:s3:::bucket-report/*.PDF",
        "arn:aws:s3:::bucket-report/*.png",
        "arn:aws:s3:::bucket-report/*.PNG",
        "arn:aws:s3:::bucket-report/*.gif",
        "arn:aws:s3:::bucket-report/*.GIF",
        "arn:aws:s3:::bucket-report/*.doc",
        "arn:aws:s3:::bucket-report/*.DOC",
        "arn:aws:s3:::bucket-report/*.docx",
        "arn:aws:s3:::bucket-report/*.DOCX",
        "arn:aws:s3:::bucket-report/*.odt",
        "arn:aws:s3:::bucket-report/*.ODT"
      ]
    }
  ]
}

```