### PR TITLE
udpateReport route should have the id as parameter

### DIFF
--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -69,7 +69,9 @@ class ReportController @Inject()(reportOrchestrator: ReportOrchestrator,
     )
   }
 
-  def updateReport = SecuredAction(WithPermission(UserPermission.updateReport)).async(parse.json) { implicit request =>
+  def updateReport(uuid: String) = updateReportDeprecated
+
+  def updateReportDeprecated = SecuredAction(WithPermission(UserPermission.updateReport)).async(parse.json) { implicit request =>
 
     logger.debug("updateReport")
 

--- a/conf/routes
+++ b/conf/routes
@@ -22,7 +22,8 @@ GET          /api/reports/:uuid                         controllers.ReportContro
 DELETE       /api/reports/:uuid                         controllers.ReportController.deleteReport(uuid)
 
 POST         /api/reports                               controllers.ReportController.createReport()
-PUT          /api/reports                               controllers.ReportController.updateReport()
+PUT          /api/reports                               controllers.ReportController.updateReportDeprecated()
+PUT          /api/reports/:uuid                         controllers.ReportController.updateReport(uuid)
 POST         /api/reports/:uuid/response                controllers.ReportController.reportResponse(uuid)
 
 GET          /api/nbReportsGroupByCompany               controllers.ReportController.getNbReportsGroupByCompany(offset: Option[Long], limit: Option[Int])

--- a/test/controllers/report/CreateUpdateReportSpec.scala
+++ b/test/controllers/report/CreateUpdateReportSpec.scala
@@ -172,7 +172,7 @@ trait CreateUpdateReportSpec extends Specification with AppSpec with FutureMatch
 
   def updateReport(reportData: Report) = {
     implicit val someUserRole = Some(concernedAdminUser.userRole)
-    Await.result(app.injector.instanceOf[ReportController].updateReport().apply(
+    Await.result(app.injector.instanceOf[ReportController].updateReport(reportData.id.get.toString).apply(
       FakeRequest()
       .withAuthenticator[AuthEnv](concernedAdminLoginInfo)
       .withBody(Json.toJson(reportData))), Duration.Inf)


### PR DESCRIPTION
Le but est que toutes les URL qui concernent un report puissent avoir un `withReport(uuid)`. Quand cette PR sera déployée je mettrai à jour le front puis je supprimerai l'API sans id