### PR TITLE
Universal tokens, no company needed

### DIFF
--- a/app.json
+++ b/app.json
@@ -80,7 +80,7 @@
       "required": true
     },
     "WEBSITE_URL": {
-      "value": "https://signalement-app-pr-323.herokuapp.com"
+      "value": "https://signalement-app-pr-232.herokuapp.com"
     }
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -80,7 +80,7 @@
       "required": true
     },
     "WEBSITE_URL": {
-      "required": true
+      "value": "https://signalement-app-pr-323.herokuapp.com"
     }
   },
   "formation": {

--- a/app/controllers/AccountController.scala
+++ b/app/controllers/AccountController.scala
@@ -184,7 +184,7 @@ class AccountController @Inject()(
       }
     )
   }
-  def sendDGCCRFInvitation = SecuredAction(WithPermission(UserPermission.inviteDCCRF)).async(parse.json) { implicit request =>
+  def sendDGCCRFInvitation = SecuredAction(WithPermission(UserPermission.inviteDGCCRF)).async(parse.json) { implicit request =>
     request.body.validate[EmailAddress]((JsPath \ "email").read[EmailAddress]).fold(
       errors => {
         Future.successful(BadRequest(JsError.toJson(errors)))

--- a/app/controllers/AccountController.scala
+++ b/app/controllers/AccountController.scala
@@ -29,7 +29,7 @@ class AccountController @Inject()(
                                    userRepository: UserRepository,
                                    companyRepository: CompanyRepository,
                                    accessTokenRepository: AccessTokenRepository,
-                                   companyAccessOrchestrator: AccessesOrchestrator,
+                                   accessesOrchestrator: AccessesOrchestrator,
                                    reportRepository: ReportRepository,
                                    eventRepository: EventRepository,
                                    credentialsProvider: CredentialsProvider,
@@ -73,12 +73,12 @@ class AccountController @Inject()(
       },
       {
         case ActivationRequest(draftUser, tokenInfo) =>
-          companyAccessOrchestrator
+          accessesOrchestrator
             .handleActivationRequest(draftUser, tokenInfo)
             .map {
-              case companyAccessOrchestrator.ActivationOutcome.NotFound      => NotFound
-              case companyAccessOrchestrator.ActivationOutcome.EmailConflict => Conflict  // HTTP 409
-              case companyAccessOrchestrator.ActivationOutcome.Success       => NoContent
+              case accessesOrchestrator.ActivationOutcome.NotFound      => NotFound
+              case accessesOrchestrator.ActivationOutcome.EmailConflict => Conflict  // HTTP 409
+              case accessesOrchestrator.ActivationOutcome.Success       => NoContent
             }
       }
     )

--- a/app/controllers/AccountController.scala
+++ b/app/controllers/AccountController.scala
@@ -14,12 +14,12 @@ import javax.inject.{Inject, Singleton}
 import models._
 import orchestrators._
 import play.api._
-import play.api.libs.json.{JsError, Json}
+import play.api.libs.json.{JsError, Json, JsPath}
 import repositories._
 import utils.Constants.ReportStatus.A_TRAITER
 import utils.Constants.{ActionEvent, ReportStatus}
 import utils.silhouette.auth.{AuthEnv, WithPermission}
-import utils.SIRET
+import utils.{SIRET, EmailAddress}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -183,9 +183,22 @@ class AccountController @Inject()(
         }
       }
     )
-
   }
-
+  def sendDGCCRFInvitation = SecuredAction(WithPermission(UserPermission.inviteDCCRF)).async(parse.json) { implicit request =>
+    request.body.validate[EmailAddress]((JsPath \ "email").read[EmailAddress]).fold(
+      errors => {
+        Future.successful(BadRequest(JsError.toJson(errors)))
+      },
+      email => accessesOrchestrator.sendDGCCRFInvitation(email).map(_ => Ok)
+    )
+  }
+  def fetchTokenInfo(token: String) = UnsecuredAction.async { implicit request =>
+    for {
+      accessToken <- accessTokenRepository.findToken(token)
+    } yield accessToken.map(t =>
+      Ok(Json.toJson(TokenInfo(t.token, t.kind, None, t.emailedTo)))
+    ).getOrElse(NotFound)
+  }
 }
 
 object AccountObjects {

--- a/app/controllers/AccountController.scala
+++ b/app/controllers/AccountController.scala
@@ -72,9 +72,9 @@ class AccountController @Inject()(
         Future.successful(BadRequest(JsError.toJson(errors)))
       },
       {
-        case ActivationRequest(draftUser, tokenInfo) =>
+        case ActivationRequest(draftUser, token, companySiret) =>
           accessesOrchestrator
-            .handleActivationRequest(draftUser, tokenInfo)
+            .handleActivationRequest(draftUser, token, companySiret)
             .map {
               case accessesOrchestrator.ActivationOutcome.NotFound      => NotFound
               case accessesOrchestrator.ActivationOutcome.EmailConflict => Conflict  // HTTP 409

--- a/app/controllers/CompanyAccessController.scala
+++ b/app/controllers/CompanyAccessController.scala
@@ -17,7 +17,7 @@ class CompanyAccessController @Inject()(
                                 val userRepository: UserRepository,
                                 val companyRepository: CompanyRepository,
                                 val accessTokenRepository: AccessTokenRepository,
-                                val companyAccessOrchestrator: AccessesOrchestrator,
+                                val accessesOrchestrator: AccessesOrchestrator,
                                 val silhouette: Silhouette[AuthEnv]
                               )(implicit ec: ExecutionContext)
  extends BaseCompanyController {
@@ -71,7 +71,7 @@ class CompanyAccessController @Inject()(
     implicit val reads = Json.reads[AccessInvitation]
     request.body.validate[AccessInvitation].fold(
       errors => Future.successful(BadRequest(JsError.toJson(errors))),
-      invitation => companyAccessOrchestrator
+      invitation => accessesOrchestrator
                     .addUserOrInvite(request.company, invitation.email, invitation.level, request.identity)
                     .map(_ => Ok)
     )

--- a/app/controllers/CompanyAccessController.scala
+++ b/app/controllers/CompanyAccessController.scala
@@ -128,7 +128,7 @@ class CompanyAccessController @Inject()(
                       .getOrElse(Future(None))
           applied <- token.map(t =>
                       accessTokenRepository
-                      .applyToken(t, request.identity)
+                      .applyCompanyToken(t, request.identity)
                     ).getOrElse(Future(false))
         } yield if (applied) Ok else NotFound
     )

--- a/app/controllers/CompanyAccessController.scala
+++ b/app/controllers/CompanyAccessController.scala
@@ -83,7 +83,7 @@ class CompanyAccessController @Inject()(
     } yield Ok(Json.toJson(tokens.map(token =>
       Json.obj(
           "id"              -> token.id.toString,
-          "level"           -> token.level.value,
+          "level"           -> token.companyLevel.get.value,
           "emailedTo"       -> token.emailedTo,
           "expirationDate"  -> token.expirationDate
       )
@@ -103,7 +103,7 @@ class CompanyAccessController @Inject()(
       token   <- company.map(accessTokenRepository.findToken(_, token))
                         .getOrElse(Future(None))
     } yield token.flatMap(t => company.map(c => 
-      Ok(Json.toJson(TokenInfo(t.token, c.siret, t.emailedTo)))
+      Ok(Json.toJson(TokenInfo(t.token, t.kind, Some(c.siret), t.emailedTo)))
     )).getOrElse(NotFound)
   }
 

--- a/app/models/AccessToken.scala
+++ b/app/models/AccessToken.scala
@@ -47,9 +47,9 @@ object TokenInfo {
 
 case class ActivationRequest(
   draftUser: DraftUser,
-  tokenInfo: TokenInfo
+  token: String,
+  companySiret: Option[SIRET],
 )
 object ActivationRequest {
-  implicit val tokenInfoFormat = Json.format[TokenInfo]
   implicit val ActivationRequestFormat = Json.format[ActivationRequest]
 }

--- a/app/models/AccessToken.scala
+++ b/app/models/AccessToken.scala
@@ -6,19 +6,39 @@ import play.api.libs.json._
 import utils.{EmailAddress, SIRET}
 
 
+sealed case class TokenKind(value: String)
+
+object TokenKind {
+  val COMPANY_INIT = TokenKind("COMPANY_INIT")
+  val COMPANY_JOIN = TokenKind("COMPANY_JOIN")
+  val DGCCRF_ACCOUNT = TokenKind("DGCCRF_ACCOUNT")
+
+  def fromValue(v: String) = {
+    List(COMPANY_INIT, COMPANY_JOIN, DGCCRF_ACCOUNT).find(_.value == v).head
+  }
+  implicit val reads = new Reads[TokenKind] {
+    def reads(json: JsValue): JsResult[TokenKind] = json.validate[String].map(fromValue(_))
+  }
+  implicit val writes = new Writes[TokenKind] {
+    def writes(kind: TokenKind) = Json.toJson(kind.value)
+  }
+}
+
 case class AccessToken(
   id: UUID,
-  companyId: UUID,
+  kind: TokenKind,
   token: String,
-  level: AccessLevel,
   valid: Boolean,
+  companyId: Option[UUID],
+  companyLevel: Option[AccessLevel],
   emailedTo: Option[EmailAddress],
   expirationDate: Option[OffsetDateTime]
 )
 
 case class TokenInfo(
   token: String,
-  companySiret: SIRET,
+  kind: TokenKind,
+  companySiret: Option[SIRET],
   emailedTo: Option[EmailAddress]
 )
 object TokenInfo {

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -68,7 +68,8 @@ object UserPermission extends Enumeration {
       createEvent,
       activateAccount,
       editDocuments,
-      subscribeReports = Value
+      subscribeReports,
+      inviteDCCRF = Value
 
   implicit val enumReads: Reads[UserPermission.Value] = EnumUtils.enumReads(UserPermission)
 

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -69,7 +69,7 @@ object UserPermission extends Enumeration {
       activateAccount,
       editDocuments,
       subscribeReports,
-      inviteDCCRF = Value
+      inviteDGCCRF = Value
 
   implicit val enumReads: Reads[UserPermission.Value] = EnumUtils.enumReads(UserPermission)
 

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -85,7 +85,6 @@ class AccessesOrchestrator @Inject()(companyRepository: CompanyRepository,
   }
   import ActivationOutcome._
   def handleActivationRequest(draftUser: DraftUser, token: String, siret: Option[SIRET]): Future[ActivationOutcome] = {
-    // FIXME: handle case without siret
     val workflow = siret.map(s => new CompanyTokenWorkflow(draftUser, token, s))
                         .getOrElse(new GenericTokenWorkflow(draftUser, token))
     workflow.run

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -26,36 +26,74 @@ class AccessesOrchestrator @Inject()(companyRepository: CompanyRepository,
   val tokenDuration = configuration.getOptional[String]("play.tokens.duration").map(java.time.Period.parse(_))
   val websiteUrl = configuration.get[String]("play.website.url")
 
+  abstract class TokenWorkflow(draftUser: DraftUser, token: String) {
+    def log(msg: String) = logger.debug(s"${this.getClass.getSimpleName} - ${msg}")
+  
+    def fetchToken: Future[Option[AccessToken]]
+    def run: Future[Boolean]
+    def createUser(accessToken: AccessToken, role: UserRole): Future[User] = {
+      // If invited on emailedTo, user should register using that email
+      val email = accessToken.emailedTo.getOrElse(draftUser.email)
+      userRepository
+      .create(User(
+        UUID.randomUUID, draftUser.password, draftUser.email,
+        draftUser.firstName, draftUser.lastName, role))
+      .map(u => {
+        log(s"User with id ${u.id} created through token ${accessToken.id}")
+        u
+      })
+    }
+  }
+  
+  class GenericTokenWorkflow(draftUser: DraftUser, token: String) extends TokenWorkflow(draftUser, token) {
+    def fetchToken = { accessTokenRepository.findToken(token) }
+    def run = for {
+      accessToken <- fetchToken
+      user        <- accessToken.filter(_.kind == TokenKind.DGCCRF_ACCOUNT)
+                                .map(t => createUser(t, UserRoles.DGCCRF).map(Some(_)))
+                                .getOrElse(Future(None))
+      _           <- user.flatMap(_ => accessToken)
+                         .map(accessTokenRepository.invalidateToken)
+                         .getOrElse(Future(0))
+    } yield user.isDefined
+  }
+
+  class CompanyTokenWorkflow(draftUser: DraftUser, token: String, siret: SIRET) extends TokenWorkflow(draftUser, token) {
+    def fetchCompany: Future[Option[Company]] = companyRepository.findBySiret(siret)
+    def fetchToken: Future[Option[AccessToken]] = for {
+        company     <- fetchCompany
+        accessToken <- company.map(accessTokenRepository.findToken(_, token)).getOrElse(Future(None))
+      } yield accessToken
+    def bindPendingTokens(user: User) =
+      accessTokenRepository
+      .fetchPendingTokens(user.email)
+      .flatMap(tokens =>
+        Future.sequence(tokens.filter(_.companyId.isDefined).map(accessTokenRepository.applyCompanyToken(_, user)))
+      )
+    def run = for {
+      accessToken <- fetchToken
+      user        <- accessToken.map(t => createUser(t, UserRoles.Pro).map(Some(_))).getOrElse(Future(None))
+      applied     <- (for { u <- user; t <- accessToken }
+                        yield accessTokenRepository.applyCompanyToken(t, u)).getOrElse(Future(false))
+      _           <- user.map(bindPendingTokens(_)).getOrElse(Future(Nil))
+    } yield applied
+  }
+
   object ActivationOutcome extends Enumeration {
     type ActivationOutcome = Value
     val Success, NotFound, EmailConflict = Value
   }
   import ActivationOutcome._
   def handleActivationRequest(draftUser: DraftUser, token: String, siret: Option[SIRET]): Future[ActivationOutcome] = {
-    for {
-      // FIXME: handle different token kinds (without company)
-      company     <- siret.map(siret => companyRepository.findBySiret(siret)).getOrElse(Future(None))
-      token       <- company.map(accessTokenRepository.findToken(_, token)).getOrElse(Future(None))
-      user        <- token.map(_ => {
-                      val email = token.flatMap(_.emailedTo).getOrElse(draftUser.email)
-                      userRepository.create(User(
-                        UUID.randomUUID(), draftUser.password, email,
-                        draftUser.firstName, draftUser.lastName, UserRoles.Pro)).map(Some(_))
-                      }).getOrElse(Future(None))
-      applied     <- user.map(accessTokenRepository.applyToken(token.get, _))
-                         .getOrElse(Future(false))
-      // If the token pointed to an email (hence validated), bind other tokens with same email
-      _           <- token.flatMap(_.emailedTo).flatMap(_ => user).map(u =>
-                        accessTokenRepository
-                        .fetchPendingTokens(u.email)
-                        .flatMap(tokens =>
-                          Future.sequence(tokens.map(accessTokenRepository.applyToken(_, u)))
-                        )
-                      ).getOrElse(Future(Nil))
-    } yield if (applied) ActivationOutcome.Success else ActivationOutcome.NotFound
-  } recover {
-    case (e: org.postgresql.util.PSQLException) if e.getMessage.contains("email_unique")
-      => ActivationOutcome.EmailConflict
+    // FIXME: handle case without siret
+    val workflow = siret.map(s => new CompanyTokenWorkflow(draftUser, token, s))
+                        .getOrElse(new GenericTokenWorkflow(draftUser, token))
+    workflow.run
+            .map(if (_) ActivationOutcome.Success else ActivationOutcome.NotFound)
+            .recover {
+              case (e: org.postgresql.util.PSQLException) if e.getMessage.contains("email_unique")
+                => ActivationOutcome.EmailConflict
+            }
   }
 
   def addUserOrInvite(company: Company, email: EmailAddress, level: AccessLevel, invitedBy: User): Future[Unit] =

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -124,7 +124,7 @@ class AccessesOrchestrator @Inject()(companyRepository: CompanyRepository,
     emailedTo: EmailAddress
   ): Future[String] =
     for {
-      existingToken <- accessTokenRepository.fetchValidToken(company, emailedTo)
+      existingToken <- accessTokenRepository.fetchToken(company, emailedTo)
       _             <- existingToken.map(accessTokenRepository.updateToken(_, level, validity)).getOrElse(Future(None))
       token         <- existingToken.map(Future(_)).getOrElse(
                         accessTokenRepository.createToken(

--- a/app/repositories/AccessTokenRepository.scala
+++ b/app/repositories/AccessTokenRepository.scala
@@ -23,7 +23,7 @@ class AccessTokenRepository @Inject()(dbConfigProvider: DatabaseConfigProvider,
   import companyRepository.AccessLevelColumnType
   implicit val TokenKindColumnType = MappedColumnType.base[TokenKind, String](_.value, TokenKind.fromValue(_))
 
-  class AccessTokenTable(tag: Tag) extends Table[AccessToken](tag, "company_access_tokens") {
+  class AccessTokenTable(tag: Tag) extends Table[AccessToken](tag, "access_tokens") {
     def id = column[UUID]("id", O.PrimaryKey)
     def kind = column[TokenKind]("kind")
     def token = column[String]("token")

--- a/app/repositories/AccessTokenRepository.scala
+++ b/app/repositories/AccessTokenRepository.scala
@@ -61,7 +61,7 @@ class AccessTokenRepository @Inject()(dbConfigProvider: DatabaseConfigProvider,
   private def fetchCompanyValidTokens(company: Company) =
     fetchValidTokens.filter(_.companyId === company.id)
 
-  def fetchValidToken(company: Company, emailedTo: EmailAddress): Future[Option[AccessToken]] =
+  def fetchToken(company: Company, emailedTo: EmailAddress): Future[Option[AccessToken]] =
     db.run(fetchCompanyValidTokens(company)
       .filter(_.emailedTo === emailedTo)
       .sortBy(_.expirationDate.desc)

--- a/app/repositories/AccessTokenRepository.scala
+++ b/app/repositories/AccessTokenRepository.scala
@@ -87,6 +87,7 @@ class AccessTokenRepository @Inject()(dbConfigProvider: DatabaseConfigProvider,
   def findToken(token: String): Future[Option[AccessToken]] =
     db.run(fetchValidTokens
       .filter(_.token === token)
+      .filterNot(_.companyId.isDefined)
       .result
       .headOption
     )

--- a/app/views/mails/dgccrf/accessLink.scala.html
+++ b/app/views/mails/dgccrf/accessLink.scala.html
@@ -1,0 +1,37 @@
+@(invitationUrl: String)
+
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Accédez à SignalConso</title>
+    </head>
+    <body>
+        <div style="margin: 0 auto; max-width: 650px; width: 100%; padding: 1em; font-size: 16px">
+            <div style="text-align: center; margin: 30px auto 50px">
+                <img src="cid:logo" style="max-width: 400px; vertical-align: middle"/>
+                <br>
+            </div>
+
+            <p>
+                Bonjour,
+            </p>
+
+            <p>
+                Vous avez été invité à rejoindre SignalConso en tant qu'agent de la DGCCRF.
+                Afin de procéder, veuillez suivre le lien sécurisé ci-dessous.
+            </p>
+
+            <p style="text-align: center;">
+                <a href="@invitationUrl">@invitationUrl</a>
+            </p>
+
+            <p>Cordialement,</p>
+
+            <p>
+                <i>L'équipe SignalConso</i>
+            </p>
+
+        </div>
+    </body>
+</html>

--- a/app/views/mails/dgccrf/accessLink.scala.html
+++ b/app/views/mails/dgccrf/accessLink.scala.html
@@ -18,12 +18,12 @@
             </p>
 
             <p>
-                Vous avez été invité à rejoindre SignalConso en tant qu'agent de la DGCCRF.
-                Afin de procéder, veuillez suivre le lien sécurisé ci-dessous.
+                Vous avez été invité à accéder à l'interface DGCCRF sur SignalConso.
+                Afin de procéder, veuillez suivre le lien sécurisé ci-dessous :
             </p>
 
             <p style="text-align: center;">
-                <a href="@invitationUrl">@invitationUrl</a>
+                <a href="@invitationUrl">Finaliser mon inscription</a>
             </p>
 
             <p>Cordialement,</p>

--- a/conf/evolutions/default/31.sql
+++ b/conf/evolutions/default/31.sql
@@ -3,9 +3,9 @@
 ALTER TABLE company_access_tokens ADD COLUMN kind VARCHAR;
 ALTER TABLE company_access_tokens ALTER COLUMN company_id DROP NOT NULL;
 ALTER TABLE company_access_tokens ALTER COLUMN level DROP NOT NULL;
+ALTER TABLE company_access_tokens RENAME TO access_tokens;
 
 -- !Downs
 
+ALTER TABLE access_tokens RENAME TO company_access_tokens;
 ALTER TABLE company_access_tokens DROP COLUMN kind;
-ALTER TABLE company_access_tokens ALTER COLUMN company_id SET NOT NULL;
-ALTER TABLE company_access_tokens ALTER COLUMN level SET NOT NULL;

--- a/conf/evolutions/default/31.sql
+++ b/conf/evolutions/default/31.sql
@@ -1,0 +1,11 @@
+-- !Ups
+
+ALTER TABLE company_access_tokens ADD COLUMN kind VARCHAR;
+ALTER TABLE company_access_tokens ALTER COLUMN company_id DROP NOT NULL;
+ALTER TABLE company_access_tokens ALTER COLUMN level DROP NOT NULL;
+
+-- !Downs
+
+ALTER TABLE company_access_tokens DROP COLUMN kind;
+ALTER TABLE company_access_tokens ALTER COLUMN company_id SET NOT NULL;
+ALTER TABLE company_access_tokens ALTER COLUMN level SET NOT NULL;

--- a/conf/evolutions/default/31.sql
+++ b/conf/evolutions/default/31.sql
@@ -1,6 +1,6 @@
 -- !Ups
 
-ALTER TABLE company_access_tokens ADD COLUMN kind VARCHAR;
+ALTER TABLE company_access_tokens ADD COLUMN kind VARCHAR NOT NULL;
 ALTER TABLE company_access_tokens ALTER COLUMN company_id DROP NOT NULL;
 ALTER TABLE company_access_tokens ALTER COLUMN level DROP NOT NULL;
 ALTER TABLE company_access_tokens RENAME TO access_tokens;

--- a/conf/evolutions/default/31.sql
+++ b/conf/evolutions/default/31.sql
@@ -1,6 +1,8 @@
 -- !Ups
 
-ALTER TABLE company_access_tokens ADD COLUMN kind VARCHAR NOT NULL;
+ALTER TABLE company_access_tokens ADD COLUMN kind VARCHAR;
+UPDATE company_access_tokens SET kind = CASE WHEN emailed_to IS NULL THEN 'COMPANY_INIT' ELSE 'COMPANY_JOIN' END WHERE kind IS NULL;
+ALTER TABLE company_access_tokens ALTER COLUMN kind SET NOT NULL;
 ALTER TABLE company_access_tokens ALTER COLUMN company_id DROP NOT NULL;
 ALTER TABLE company_access_tokens ALTER COLUMN level DROP NOT NULL;
 ALTER TABLE company_access_tokens RENAME TO access_tokens;

--- a/conf/routes
+++ b/conf/routes
@@ -66,10 +66,12 @@ DELETE      /api/accesses/:siret/token/:tokenId         controllers.CompanyAcces
 POST        /api/accesses/:siret/invitation             controllers.CompanyAccessController.sendInvitation(siret: String)
 
 # Account API
+GET         /api/account/token                          controllers.AccountController.fetchTokenInfo(token: String)
 POST        /api/account/password                       controllers.AccountController.changePassword
 POST        /api/account/activation                     controllers.AccountController.activateAccount
 GET         /api/account/:siret/document/activation     controllers.AccountController.getActivationDocument(siret)
 POST        /api/account/document/activation            controllers.AccountController.getActivationDocumentForReportList()
+POST        /api/account/dgccrf/invitation              controllers.AccountController.sendDGCCRFInvitation
 
 # Rating API
 POST        /api/rating                                 controllers.RatingController.rate

--- a/test/controllers/AccessControllerSpec.scala
+++ b/test/controllers/AccessControllerSpec.scala
@@ -180,6 +180,7 @@ The invitation workflow should
     contentAsJson(result) must beEqualTo(
       Json.obj(
         "token" -> invitationToken.token,
+        "kind" -> "COMPANY_JOIN",
         "companySiret" -> company.siret,
         "emailedTo" -> invitedEmail
       )
@@ -211,7 +212,7 @@ class UserAcceptTokenSpec(implicit ee: ExecutionEnv) extends BaseAccessControlle
 
   def e2 = {
     token = Await.result(
-      accessTokenRepository.createToken(newCompany, AccessLevel.ADMIN, "123456", None, None),
+      accessTokenRepository.createToken(TokenKind.COMPANY_JOIN, "123456", None, Some(newCompany), Some(AccessLevel.ADMIN), None),
       Duration.Inf
     )
     token must haveClass [AccessToken]

--- a/test/controllers/AccountControllerSpec.scala
+++ b/test/controllers/AccountControllerSpec.scala
@@ -51,7 +51,7 @@ class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification wit
     Await.result(for {
       _ <- userRepository.create(proUser)
       _ <- companyRepository.getOrCreate(company.siret, company)
-      _ <- accessTokenRepository.createToken(company, AccessLevel.ADMIN, "123456", None, None)
+      _ <- accessTokenRepository.createToken(TokenKind.COMPANY_JOIN, "123456", None, Some(company), Some(AccessLevel.ADMIN), None)
     } yield Unit,
     Duration.Inf)
   }
@@ -90,6 +90,7 @@ class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification wit
             ),
             "tokenInfo" -> Json.obj(
               "token" -> "123456",
+              "kind" -> "COMPANY_INIT",
               "companySiret" -> company.siret
             )
           ))
@@ -104,8 +105,8 @@ class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification wit
         val otherCompany = Fixtures.genCompany.sample.get
         val otherToken = Await.result(for {
           _ <- companyRepository.getOrCreate(otherCompany.siret, otherCompany)
-          _ <- accessTokenRepository.createToken(company, AccessLevel.ADMIN, "000000", None, Some(newUser.email))
-          token <- accessTokenRepository.createToken(otherCompany, AccessLevel.ADMIN, "whatever", None, Some(newUser.email))
+          _ <- accessTokenRepository.createToken(TokenKind.COMPANY_JOIN, "000000", None, Some(company), Some(AccessLevel.ADMIN), Some(newUser.email))
+          token <- accessTokenRepository.createToken(TokenKind.COMPANY_JOIN, "whatever", None, Some(otherCompany), Some(AccessLevel.ADMIN), Some(newUser.email))
         } yield token,
         Duration.Inf)
         val request = FakeRequest(POST, routes.AccountController.activateAccount.toString)
@@ -118,6 +119,7 @@ class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification wit
             ),
             "tokenInfo" -> Json.obj(
               "token" -> "000000",
+              "kind" -> "COMPANY_INIT",
               "companySiret" -> company.siret
             )
           ))

--- a/test/controllers/AccountControllerSpec.scala
+++ b/test/controllers/AccountControllerSpec.scala
@@ -88,11 +88,8 @@ class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification wit
               "lastName" -> proUser.lastName,
               "password" -> proUser.password
             ),
-            "tokenInfo" -> Json.obj(
-              "token" -> "123456",
-              "kind" -> "COMPANY_INIT",
-              "companySiret" -> company.siret
-            )
+            "token" -> "123456",
+            "companySiret" -> company.siret
           ))
 
         val result = route(app, request).get
@@ -117,11 +114,8 @@ class AccountControllerSpec(implicit ee: ExecutionEnv) extends Specification wit
               "lastName" -> newUser.lastName,
               "password" -> newUser.password
             ),
-            "tokenInfo" -> Json.obj(
-              "token" -> "000000",
-              "kind" -> "COMPANY_INIT",
-              "companySiret" -> company.siret
-            )
+            "token" -> "000000",
+            "companySiret" -> company.siret
           ))
 
         val result = route(app, request).get


### PR DESCRIPTION
Je mets ça là pour partager, mais pas prêt à merger encore

Reste à voir : 
* Mettre à jour le front (partie `/api/account/activation`)
* Ajouter des contrôles en fonction du token kind (init => pas d'email, join => email, init/join => company, etc.)
* Comment gérer les différents cas dans l'orchestrateur ? (voir les FIXME dans `handleActivationRequest`)
* etc.