### PR TITLE
Make it clear that test keys are test keys

### DIFF
--- a/app.json
+++ b/app.json
@@ -67,6 +67,9 @@
     "REPORT_TASK_INTERVAL": {
       "value": "1"
     },
+    "S3_ACCESS_KEY_ID": {
+      "required": true
+    },
     "S3_SECRET_ACCESS_KEY": {
       "required": true
     },

--- a/conf/common/s3.conf
+++ b/conf/common/s3.conf
@@ -19,7 +19,6 @@ alpakka.s3 {
       provider = static
       access-key-id = "4DPZSQC8P085QBIRXU6F"
       access-key-id = ${?S3_ACCESS_KEY_ID}
-      secret-access-key = "EtMD4pF003yzrpRr31fzRpxyivKsUtTWF12CwxjO"
       secret-access-key = ${?S3_SECRET_ACCESS_KEY}
     }
 

--- a/conf/common/s3.conf
+++ b/conf/common/s3.conf
@@ -17,9 +17,9 @@ alpakka.s3 {
   aws {
     credentials {
       provider = static
-      access-key-id = "4DPZSQC8P085QBIRXU6F"
+      access-key-id = "dummy-access-key"
       access-key-id = ${?S3_ACCESS_KEY_ID}
-      secret-access-key = "test"
+      secret-access-key = "dummy-secret-key"
       secret-access-key = ${?S3_SECRET_ACCESS_KEY}
     }
 

--- a/conf/common/s3.conf
+++ b/conf/common/s3.conf
@@ -19,6 +19,7 @@ alpakka.s3 {
       provider = static
       access-key-id = "4DPZSQC8P085QBIRXU6F"
       access-key-id = ${?S3_ACCESS_KEY_ID}
+      secret-access-key = "test"
       secret-access-key = ${?S3_SECRET_ACCESS_KEY}
     }
 

--- a/conf/common/silhouette.conf
+++ b/conf/common/silhouette.conf
@@ -7,9 +7,9 @@ silhouette {
     issuerClaim="play-angular-silhouette"
     encryptSubject=true
     authenticatorExpiry=12 hours
-    sharedSecret="J4ZfUzOesCMAzbqWhSsC3g5hYXBqK274QdpA"
+    sharedSecret="test-J4ZfUzOesCMAzbqWhSsC3g5hYXBqK274QdpA"
     sharedSecret=${?AUTHENTICATOR_SECRET}
-    crypter.key = "QwtgUNd8JwEcBgON64ZfVZJYStIV5FfFF1QO" // A unique encryption key
+    crypter.key = "test-QwtgUNd8JwEcBgON64ZfVZJYStIV5FfFF1QO"
     crypter.key = ${?CRYPTER_KEY}
     requestParts = ["headers", "query-string"]
 
@@ -22,7 +22,7 @@ silhouette {
 
   apiKeyAuthenticator {
     headerName="X-Api-Key"
-    sharedSecret="664jQJF9bhCRNs33H7Rwh2kny54N"
+    sharedSecret="test-664jQJF9bhCRNs33H7Rwh2kny54N"
     sharedSecret=${?API_KEY_AUTHENTICATOR_SECRET}
   }
 }


### PR DESCRIPTION
@jrivals pour éviter qu'on nous ressorte la même chose au prochain audit (j'avais vu ce genre de formats pour des clefs de tests de Stripe, pratique pour pas mélanger)