### PR TITLE
Update monthly stats

### DIFF
--- a/scripts/stats.sql
+++ b/scripts/stats.sql
@@ -83,10 +83,13 @@ group by category;
 -- % signalements internets (signalements des 30 derniers jours)
 select count(1) "Nb signalements des 30 derniers jours",
        ((count(*) filter ( where website_url is not null ))::numeric / count(1)::numeric * 100)::numeric(5,2) "% signalement internet",
-       ((count(*) filter ( where website_url is not null and company_id is not null ))::numeric / count(1)::numeric * 100)::numeric(5,2) "% signalement internet avec entreprise identifiée",
+       ((count(*) filter ( where website_url is not null and company_id is not null and not exists(
+               select * from events e where e.report_id = reports.id and e.action = 'Modification du commerçant'
+           )))::numeric / (count(*) filter ( where website_url is not null ))::numeric * 100)::numeric(5,2) "% sign entreprise ident par conso parmi les sign internets",
        ((count(*) filter ( where website_url is not null and company_id is not null and exists(
                select * from events e where e.report_id = reports.id and e.action = 'Modification du commerçant'
-           )))::numeric / count(1)::numeric * 100)::numeric(5,2) "% signalement internet avec entreprise identifiée par admin"
+           )))::numeric / (count(*) filter ( where website_url is not null ))::numeric * 100)::numeric(5,2) "% sign entreprise ident par admin parmi les sign internets",
+       ((count(*) filter ( where website_url is not null and company_id is null ))::numeric / (count(*) filter ( where website_url is not null ))::numeric * 100)::numeric(5,2) "% sign entreprise ident par le conso parmi les sign internets"
 from reports
 where creation_date >= 'now'::timestamp - '30 days'::interval;
 


### PR DESCRIPTION
Suite réunion d'équipe, modification des stats sur les signalements internet.
Nouveaux indicateurs :
- % de signalements internet parmi les signalements des 30 derniers jours
- % de signalements identifiés par le conso parmi les signalements internet des 30 derniers jours
- % de signalements identifiés par l’admin parmi les signalements internet des 30 derniers jours
- % de signalements non identifiés parmi les signalements internet des 30 derniers jours