### PR TITLE
Add error details on failed auth attempt

### DIFF
--- a/app/controllers/AccountController.scala
+++ b/app/controllers/AccountController.scala
@@ -9,6 +9,7 @@ import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
 import config.AppConfigLoader
 import models._
 import models.access.ActivationOutcome
+import models.auth.PasswordChange
 import models.token.TokenKind.ValidateEmail
 import orchestrators._
 import play.api._

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -5,6 +5,7 @@ import com.mohiva.play.silhouette.api.Silhouette
 import config.AppConfigLoader
 import models.DetailInputValue.toDetailInputValue
 import models._
+import models.auth.AuthToken
 import play.api.Logger
 import play.api.libs.json.JsError
 import play.api.libs.json.Json

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -1,24 +1,25 @@
 package controllers
 
-import com.mohiva.play.silhouette.api.LoginEvent
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.Silhouette
 import com.mohiva.play.silhouette.api.util.Credentials
+import com.mohiva.play.silhouette.impl.exceptions.IdentityNotFoundException
+import com.mohiva.play.silhouette.impl.exceptions.InvalidPasswordException
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
-import config.AppConfigLoader
 import models._
-import orchestrators.AccessesOrchestrator
+import orchestrators.AuthOrchestrator
 import play.api._
 import play.api.libs.json.JsError
 import play.api.libs.json.JsPath
 import play.api.libs.json.Json
+import play.api.mvc.Request
 import repositories.AuthTokenRepository
 import repositories.UserRepository
 import services.Email.ResetPassword
 import services.MailService
 import utils.silhouette.auth.AuthEnv
 import utils.silhouette.auth.UserService
-
+import error.AppErrorTransformer.handleError
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.inject.Inject
@@ -26,17 +27,17 @@ import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import error.AppError._
 
 @Singleton
 class AuthController @Inject() (
     val silhouette: Silhouette[AuthEnv],
-    accessesOrchestrator: AccessesOrchestrator,
     userRepository: UserRepository,
+    authOrchestrator: AuthOrchestrator,
     authTokenRepository: AuthTokenRepository,
     userService: UserService,
     mailService: MailService,
-    credentialsProvider: CredentialsProvider,
-    appConfigLoader: AppConfigLoader
+    credentialsProvider: CredentialsProvider
 )(implicit ec: ExecutionContext)
     extends BaseController {
 
@@ -45,51 +46,29 @@ class AuthController @Inject() (
   implicit val timeout: akka.util.Timeout = 5.seconds
 
   def authenticate = UnsecuredAction.async(parse.json) { implicit request =>
-    request.body
-      .validate[UserLogin]
-      .fold(
-        err => {
-          logger.error(s"Failure parsing UserLogin ${err}")
-          Future(BadRequest)
-        },
-        data =>
-          for {
-            _ <- userRepository.saveAuthAttempt(data.login)
-            attempts <- userRepository.countAuthAttempts(data.login, java.time.Duration.parse("PT30M"))
-            response <-
-              if (attempts > 15) Future(Forbidden)
-              else
-                credentialsProvider
-                  .authenticate(Credentials(data.login, data.password))
-                  .flatMap { loginInfo =>
-                    userService.retrieve(loginInfo).flatMap {
-                      case Some(user)
-                          if user.userRole == UserRole.DGCCRF
-                            && user.lastEmailValidation
-                              .exists(
-                                _.isBefore(
-                                  OffsetDateTime.now
-                                    .minus(appConfigLoader.get.token.dgccrfDelayBeforeRevalidation)
-                                )
-                              ) =>
-                        accessesOrchestrator.sendEmailValidation(user).map(_ => Locked)
-                      case Some(user) =>
-                        silhouette.env.authenticatorService.create(loginInfo).flatMap { authenticator =>
-                          silhouette.env.eventBus.publish(LoginEvent(user, request))
-                          silhouette.env.authenticatorService.init(authenticator).map { token =>
-                            Ok(Json.obj("token" -> token, "user" -> user))
-                          }
-                        }
-                      case None => userRepository.saveAuthAttempt(data.login).map(_ => Unauthorized)
-                    }
-                  }
-                  .recoverWith { case e =>
-                    logger.error(e.getMessage)
-                    Future(Unauthorized)
-                  }
-          } yield response
-      )
+    val resultOrError = for {
+      userLogin <- request.parseBody[UserLogin]()
+      token <- getToken(userLogin)
+      userSession <- authOrchestrator.login(userLogin, token)
+    } yield Ok(Json.toJson(userSession))
+
+    resultOrError.recover { case err => handleError(err) }
+
   }
+
+  private def getToken(userLogin: UserLogin)(implicit req: Request[_]): Future[String] = for {
+    loginInfo <- credentialsProvider
+      .authenticate(Credentials(userLogin.login, userLogin.password))
+      .recoverWith {
+        case _: InvalidPasswordException =>
+          Future.failed(InvalidPassword(userLogin.login))
+        case _: IdentityNotFoundException => Future.failed(UserNotFound(userLogin.login))
+        case err =>
+          Future.failed(ServerError("Unexpected error when authenticating user", Some(err)))
+      }
+    authenticator <- silhouette.env.authenticatorService.create(loginInfo)
+    token <- silhouette.env.authenticatorService.init(authenticator)
+  } yield token
 
   def forgotPassword = UnsecuredAction.async(parse.json) { implicit request =>
     request.body

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -1,37 +1,27 @@
 package controllers
 
-import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.Silhouette
-import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
-import models._
 import orchestrators.AuthOrchestrator
 import play.api._
-import play.api.libs.json.JsError
-import play.api.libs.json.JsPath
+import play.api.libs.json.JsValue
 import play.api.libs.json.Json
-import repositories.AuthTokenRepository
-import repositories.UserRepository
-import services.Email.ResetPassword
-import services.MailService
 import utils.silhouette.auth.AuthEnv
-import utils.silhouette.auth.UserService
 import error.AppErrorTransformer.handleError
-import java.time.OffsetDateTime
+import models.auth.UserCredentials
+import models.auth.UserLogin
+import models.auth.UserPassword
+import play.api.mvc.Action
+
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import scala.concurrent.duration._
 
 @Singleton
 class AuthController @Inject() (
     val silhouette: Silhouette[AuthEnv],
-    userRepository: UserRepository,
-    authOrchestrator: AuthOrchestrator,
-    authTokenRepository: AuthTokenRepository,
-    userService: UserService,
-    mailService: MailService
+    authOrchestrator: AuthOrchestrator
 )(implicit ec: ExecutionContext)
     extends BaseController {
 
@@ -39,56 +29,31 @@ class AuthController @Inject() (
 
   implicit val timeout: akka.util.Timeout = 5.seconds
 
-  def authenticate = UnsecuredAction.async(parse.json) { implicit request =>
+  def authenticate: Action[JsValue] = UnsecuredAction.async(parse.json) { implicit request =>
     val resultOrError = for {
-      userLogin <- request.parseBody[UserLogin]()
+      userLogin <- request.parseBody[UserCredentials]()
       userSession <- authOrchestrator.login(userLogin, request)
     } yield Ok(Json.toJson(userSession))
 
     resultOrError.recover { case err => handleError(err) }
-
   }
 
-  def forgotPassword = UnsecuredAction.async(parse.json) { implicit request =>
-    request.body
-      .validate[String]((JsPath \ "login").read[String])
-      .fold(
-        err => {
-          logger.error(s"Failure parsing UserLogin ${err}")
-          Future(BadRequest)
-        },
-        login =>
-          userService.retrieve(LoginInfo(CredentialsProvider.ID, login)).flatMap {
-            case Some(user) =>
-              for {
-                _ <- authTokenRepository.deleteForUserId(user.id)
-                authToken <-
-                  authTokenRepository.create(AuthToken(UUID.randomUUID(), user.id, OffsetDateTime.now.plusDays(1)))
-                _ <- mailService.send(ResetPassword(user, authToken))
-              } yield Ok
-            case _ =>
-              Future.successful(
-                Ok
-              ) // TODO: renvoyer une erreur? 424 FAILED_DEPENDENCY? 422 UNPROCESSABLE_ENTITY? 412 PRECONDITION_FAILED
-          }
-      )
+  def forgotPassword: Action[JsValue] = UnsecuredAction.async(parse.json) { implicit request =>
+    val resultOrError = for {
+      userLogin <- request.parseBody[UserLogin]()
+      _ <- authOrchestrator.forgotPassword(userLogin)
+    } yield Ok
+
+    resultOrError.recover { case err => handleError(err) }
   }
 
-  def resetPassword(token: UUID) = UnsecuredAction.async(parse.json) { implicit request =>
-    authTokenRepository.findValid(token).flatMap {
-      case Some(authToken) =>
-        request.body
-          .validate[String]((JsPath \ "password").read[String])
-          .fold(
-            errors => Future.successful(BadRequest(JsError.toJson(errors))),
-            password =>
-              for {
-                _ <- userRepository.updatePassword(authToken.userID, password)
-                _ <- authTokenRepository.deleteForUserId(authToken.userID)
-              } yield NoContent
-          )
-      case None => Future.successful(NotFound)
-    }
+  def resetPassword(token: UUID): Action[JsValue] = UnsecuredAction.async(parse.json) { implicit request =>
+    val resultOrError = for {
+      userPassword <- request.parseBody[UserPassword]()
+      _ <- authOrchestrator.resetPassword(token, userPassword)
+    } yield NoContent
+
+    resultOrError.recover { case err => handleError(err) }
   }
 
 }

--- a/app/controllers/error/AppError.scala
+++ b/app/controllers/error/AppError.scala
@@ -114,4 +114,11 @@ object AppError {
     override val details: String = s"Le corps de la requête ne correspond pas à ce qui est attendu par l'API."
   }
 
+  final case class TokenNotFoundOrInvalid(token: UUID) extends NotFoundError {
+    override val `type`: String = "SC-0015"
+    override val title: String = s"Token not found / invalid ${token.toString}"
+    override val details: String =
+      s"Lien invalide ou expiré, merci de recommencer la demande de changement de mot de passe."
+  }
+
 }

--- a/app/controllers/error/AppError.scala
+++ b/app/controllers/error/AppError.scala
@@ -66,7 +66,7 @@ object AppError {
       s"Le site $host doit être un site valide."
   }
 
-  final case class InvalidDGCCRFEmail(email: EmailAddress, suffix: String) extends BadRequestError {
+  final case class InvalidDGCCRFEmail(email: EmailAddress, suffix: String) extends ForbiddenError {
     override val `type`: String = "SC-0008"
     override val title: String = "Invalid Dgccrf email"
     override val details: String =

--- a/app/controllers/error/AppError.scala
+++ b/app/controllers/error/AppError.scala
@@ -4,13 +4,15 @@ import utils.EmailAddress
 import utils.SIRET
 
 import java.util.UUID
+import scala.util.control.NoStackTrace
 
-sealed trait AppError extends Throwable with Product with Serializable {
+sealed trait AppError extends Throwable with Product with Serializable with NoStackTrace {
   val `type`: String
   val title: String
   val details: String
 }
 
+sealed trait UnauthorizedError extends AppError
 sealed trait NotFoundError extends AppError
 sealed trait BadRequestError extends AppError
 sealed trait ForbiddenError extends AppError
@@ -64,7 +66,7 @@ object AppError {
       s"Le site $host doit être un site valide."
   }
 
-  final case class InvalidDGCCRFEmail(email: EmailAddress, suffix: String) extends ForbiddenError {
+  final case class InvalidDGCCRFEmail(email: EmailAddress, suffix: String) extends BadRequestError {
     override val `type`: String = "SC-0008"
     override val title: String = "Invalid Dgccrf email"
     override val details: String =
@@ -76,6 +78,40 @@ object AppError {
     override val title: String = "User already exist"
     override val details: String =
       s"Ce compte existe déjà. Merci de demander à l'utilisateur de regénérer son mot de passe pour se connecter"
+  }
+
+  final case class TooMuchAuthAttempts(userId: UUID) extends ForbiddenError {
+    override val `type`: String = "SC-0010"
+    override val title: String = s"Max auth attempt reached for user id : $userId"
+    override val details: String =
+      "Le nombre maximum de tentative d'authentification a été dépassé, merci de rééssayer un peu plus tard."
+  }
+
+  final case class InvalidPassword(login: String) extends UnauthorizedError {
+    override val `type`: String = "SC-0011"
+    override val title: String = "Invalid password"
+    override val details: String =
+      s"Mot de passe invalide pour $login"
+  }
+
+  final case class UserNotFound(login: String) extends UnauthorizedError {
+    override val `type`: String = "SC-0012"
+    override val title: String = "User not found"
+    override val details: String =
+      s"Aucun utilisateur trouvé pour $login"
+  }
+
+  final case class DGCCRFUserEmailValidationExpired(login: String) extends ForbiddenError {
+    override val `type`: String = "SC-0013"
+    override val title: String = "DGCCRF user needs email revalidation"
+    override val details: String =
+      s"Votre compte DGCCRF a besoin d'être revalidé, un email vous a été envoyé pour réactiver votre compte."
+  }
+
+  final case object MalformedBody extends BadRequestError {
+    override val `type`: String = "SC-0014"
+    override val title: String = "Malformed request body"
+    override val details: String = s"Le corps de la requête ne correspond pas à ce qui est attendu par l'API."
   }
 
 }

--- a/app/controllers/error/AppErrorTransformer.scala
+++ b/app/controllers/error/AppErrorTransformer.scala
@@ -1,6 +1,7 @@
 package controllers.error
 
 import controllers.error.AppError.ServerError
+import controllers.error.ErrorPayload.AuthenticationErrorPayload
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc.Result
@@ -43,5 +44,9 @@ object AppErrorTransformer {
       case error: InternalAppError =>
         logger.error(error.details, error)
         Results.InternalServerError(Json.toJson(ErrorPayload(error)))
+
+      case error: UnauthorizedError =>
+        logger.warn(error.details, error)
+        Results.Unauthorized(Json.toJson(AuthenticationErrorPayload))
     }
 }

--- a/app/controllers/error/AppErrorTransformer.scala
+++ b/app/controllers/error/AppErrorTransformer.scala
@@ -7,46 +7,51 @@ import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results
 
+import java.util.UUID
+
 object AppErrorTransformer {
 
   val logger: Logger = Logger(this.getClass())
 
-  def handleError(err: Throwable): Result =
+  private def formatMessage(maybeUser: Option[UUID], appError: AppError) =
+    s"""[${maybeUser.getOrElse("not_connected")}] ${appError.details}"""
+
+  def handleError(err: Throwable, maybeUserId: Option[UUID] = None): Result =
     err match {
-      case appError: AppError => handleError(appError)
+      case appError: AppError => handleError(appError, maybeUserId)
       case err =>
         logger.error("Encountered unexpected error", err)
         Results.InternalServerError(Json.toJson(ErrorPayload(ServerError("Encountered unexpected error", Some(err)))))
     }
 
-  private def handleError(error: AppError): Result =
+  private def handleError(error: AppError, maybeUserId: Option[UUID]): Result =
     error match {
       case error: NotFoundError =>
-        logger.info(error.details)
+        logger.warn(formatMessage(maybeUserId, error))
         Results.NotFound(Json.toJson(ErrorPayload(error)))
 
       case error: PreconditionError =>
-        logger.warn(error.details)
+        logger.warn(formatMessage(maybeUserId, error))
         Results.PreconditionFailed(Json.toJson(ErrorPayload(error)))
 
       case error: ConflictError =>
-        logger.warn(error.details)
+        logger.warn(formatMessage(maybeUserId, error))
         Results.Conflict(Json.toJson(ErrorPayload(error)))
 
       case error: BadRequestError =>
-        logger.warn(error.details)
+        logger.warn(formatMessage(maybeUserId, error))
         Results.BadRequest(Json.toJson(ErrorPayload(error)))
 
       case error: ForbiddenError =>
-        logger.warn(error.details)
+        logger.warn(formatMessage(maybeUserId, error))
         Results.Forbidden(Json.toJson(ErrorPayload(error)))
 
       case error: InternalAppError =>
-        logger.error(error.details, error)
+        logger.error(formatMessage(maybeUserId, error), error)
         Results.InternalServerError(Json.toJson(ErrorPayload(error)))
 
       case error: UnauthorizedError =>
-        logger.warn(error.details, error)
+        logger.warn(formatMessage(maybeUserId, error), error)
         Results.Unauthorized(Json.toJson(AuthenticationErrorPayload))
     }
 }

--- a/app/controllers/error/ErrorPayload.scala
+++ b/app/controllers/error/ErrorPayload.scala
@@ -8,5 +8,13 @@ final case class ErrorPayload(`type`: String, title: String, details: String)
 object ErrorPayload {
   def apply(error: AppError): ErrorPayload = ErrorPayload(error.`type`, error.title, error.details)
 
+  val AuthenticationErrorPayload = ErrorPayload(
+    "SC-AUTH",
+    "Cannot authenticate user",
+    """Impossible de vous authentifier,
+      | merci de vérifier que votre mot de passe ou identifiant est correct.
+      | Si vous avez oublié votre mot de passe, cliquez sur "MOT DE PASSE OUBLIÉ" pour le récupérer.""".stripMargin
+  )
+
   implicit val ErrorPayloadFormat: Format[ErrorPayload] = Json.format[ErrorPayload]
 }

--- a/app/controllers/package.scala
+++ b/app/controllers/package.scala
@@ -1,9 +1,21 @@
-import models.ReportResponseType
+import controllers.error.AppError.MalformedBody
 
+import models.ReportResponseType
 import models.website.WebsiteKind
+import play.api.Logger
+import play.api.libs.json.JsError
+import play.api.libs.json.JsValue
+import play.api.libs.json.Reads
 import play.api.mvc.QueryStringBindable
+import play.api.mvc.Request
+import cats.syntax.either._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 package object controllers {
+
+  val logger: Logger = Logger(this.getClass)
 
   implicit val WebsiteKindQueryStringBindable: QueryStringBindable[WebsiteKind] =
     QueryStringBindable.bindableString
@@ -18,4 +30,15 @@ package object controllers {
         reportResponseType => ReportResponseType.withName(reportResponseType),
         reportResponseType => reportResponseType.entryName
       )
+
+  implicit class RequestOps[T <: JsValue](request: Request[T])(implicit ec: ExecutionContext) {
+    def parseBody[B]()(implicit reads: Reads[B]) = request.body
+      .validate[B]
+      .asEither
+      .leftMap { errors =>
+        logger.warn(s"Malformed request body : ${JsError.toJson(errors)}")
+        MalformedBody
+      }
+      .liftTo[Future]
+  }
 }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -64,7 +64,9 @@ case class UserLogin(
 case class AuthAttempt(
     id: UUID,
     login: String,
-    timestamp: OffsetDateTime
+    timestamp: OffsetDateTime,
+    isSuccess: Option[Boolean],
+    failureCause: Option[String] = None
 )
 
 object UserLogin {

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -56,23 +56,6 @@ object User {
   )(User.apply _)
 }
 
-case class UserLogin(
-    login: String,
-    password: String
-)
-
-case class AuthAttempt(
-    id: UUID,
-    login: String,
-    timestamp: OffsetDateTime,
-    isSuccess: Option[Boolean],
-    failureCause: Option[String] = None
-)
-
-object UserLogin {
-  implicit val userLoginFormat = Json.format[UserLogin]
-}
-
 object UserPermission extends Enumeration {
   val listReports, updateReport, deleteReport, deleteFile, createReportAction, activateAccount, updateCompany,
       editDocuments, subscribeReports, inviteDGCCRF = Value
@@ -81,23 +64,3 @@ object UserPermission extends Enumeration {
 
   implicit def enumWrites: Writes[UserPermission.Value] = EnumUtils.enumWrites
 }
-
-case class PasswordChange(
-    newPassword: String,
-    oldPassword: String
-)
-
-object PasswordChange {
-  implicit val userReads: Reads[PasswordChange] = (
-    (JsPath \ "newPassword").read[String] and
-      (JsPath \ "oldPassword").read[String]
-  )(PasswordChange.apply _).filter(JsonValidationError("Passwords must not be equals"))(passwordChange =>
-    passwordChange.newPassword != passwordChange.oldPassword
-  )
-}
-
-case class AuthToken(
-    id: UUID,
-    userID: UUID,
-    expiry: OffsetDateTime
-)

--- a/app/models/auth/AuthAttempt.scala
+++ b/app/models/auth/AuthAttempt.scala
@@ -1,0 +1,12 @@
+package models.auth
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+case class AuthAttempt(
+    id: UUID,
+    login: String,
+    timestamp: OffsetDateTime,
+    isSuccess: Option[Boolean],
+    failureCause: Option[String] = None
+)

--- a/app/models/auth/AuthToken.scala
+++ b/app/models/auth/AuthToken.scala
@@ -1,0 +1,10 @@
+package models.auth
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+case class AuthToken(
+    id: UUID,
+    userID: UUID,
+    expiry: OffsetDateTime
+)

--- a/app/models/auth/PasswordChange.scala
+++ b/app/models/auth/PasswordChange.scala
@@ -1,0 +1,20 @@
+package models.auth
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.JsPath
+import play.api.libs.json.JsonValidationError
+import play.api.libs.json.Reads
+
+case class PasswordChange(
+    newPassword: String,
+    oldPassword: String
+)
+
+object PasswordChange {
+  implicit val userReads: Reads[PasswordChange] = (
+    (JsPath \ "newPassword").read[String] and
+      (JsPath \ "oldPassword").read[String]
+  )(PasswordChange.apply _).filter(JsonValidationError("Passwords must not be equals"))(passwordChange =>
+    passwordChange.newPassword != passwordChange.oldPassword
+  )
+}

--- a/app/models/auth/UserCredentials.scala
+++ b/app/models/auth/UserCredentials.scala
@@ -1,0 +1,12 @@
+package models.auth
+
+import play.api.libs.json.Json
+
+case class UserCredentials(
+    login: String,
+    password: String
+)
+
+object UserCredentials {
+  implicit val userLoginFormat = Json.format[UserCredentials]
+}

--- a/app/models/auth/UserLogin.scala
+++ b/app/models/auth/UserLogin.scala
@@ -1,0 +1,12 @@
+package models.auth
+
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+case class UserLogin(
+    login: String
+)
+
+object UserLogin {
+  implicit val UserLoginFormat: OFormat[UserLogin] = Json.format[UserLogin]
+}

--- a/app/models/auth/UserPassword.scala
+++ b/app/models/auth/UserPassword.scala
@@ -1,0 +1,11 @@
+package models.auth
+
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+case class UserPassword(
+    password: String
+)
+object UserPassword {
+  implicit val UserPasswordFormat: OFormat[UserPassword] = Json.format[UserPassword]
+}

--- a/app/models/auth/UserSession.scala
+++ b/app/models/auth/UserSession.scala
@@ -1,4 +1,4 @@
-package models.token
+package models.auth
 
 import models.User
 import play.api.libs.json.Json

--- a/app/models/token/UserSession.scala
+++ b/app/models/token/UserSession.scala
@@ -1,0 +1,11 @@
+package models.token
+
+import models.User
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+case class UserSession(token: String, user: User)
+
+object UserSession {
+  implicit val UserSessionFormat: OFormat[UserSession] = Json.format[UserSession]
+}

--- a/app/orchestrators/AuthOrchestrator.scala
+++ b/app/orchestrators/AuthOrchestrator.scala
@@ -3,12 +3,15 @@ package orchestrators
 import cats.implicits.catsSyntaxMonadError
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
 import controllers.error.AppError.DGCCRFUserEmailValidationExpired
+import controllers.error.AppError.InvalidPassword
+import controllers.error.AppError.ServerError
 import controllers.error.AppError.TooMuchAuthAttempts
 import controllers.error.AppError.UserNotFound
 import models.User
 import models.UserLogin
 import models.UserRole
 import repositories.UserRepository
+import utils.silhouette.auth.AuthEnv
 import utils.silhouette.auth.UserService
 
 import javax.inject.Inject
@@ -20,12 +23,17 @@ import scala.language.postfixOps
 import cats.syntax.option._
 import cats.instances.future.catsStdInstancesForFuture
 import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.api.Silhouette
+import com.mohiva.play.silhouette.api.util.Credentials
+import com.mohiva.play.silhouette.impl.exceptions.IdentityNotFoundException
+import com.mohiva.play.silhouette.impl.exceptions.InvalidPasswordException
 import config.AppConfigLoader
 import controllers.error.AppError
 import models.token.UserSession
 import orchestrators.AuthOrchestrator.AuthAttemptPeriod
 import orchestrators.AuthOrchestrator.MaxAllowedAuthAttempts
 import play.api.Logger
+import play.api.mvc.Request
 
 import java.time.OffsetDateTime
 import java.time.Period
@@ -34,7 +42,9 @@ class AuthOrchestrator @Inject() (
     userService: UserService,
     userRepository: UserRepository,
     accessesOrchestrator: AccessesOrchestrator,
-    appConfigLoader: AppConfigLoader
+    appConfigLoader: AppConfigLoader,
+    credentialsProvider: CredentialsProvider,
+    val silhouette: Silhouette[AuthEnv]
 )(implicit
     ec: ExecutionContext
 ) {
@@ -42,7 +52,7 @@ class AuthOrchestrator @Inject() (
   private val logger: Logger = Logger(this.getClass)
   private val dgccrfDelayBeforeRevalidation: Period = appConfigLoader.get.token.dgccrfDelayBeforeRevalidation
 
-  def login(userLogin: UserLogin, token: String): Future[UserSession] = {
+  def login(userLogin: UserLogin, request: Request[_]): Future[UserSession] = {
 
     val eventualUserSession: Future[UserSession] = for {
       maybeUser <- userService.retrieve(LoginInfo(CredentialsProvider.ID, userLogin.login))
@@ -53,6 +63,7 @@ class AuthOrchestrator @Inject() (
       _ = logger.debug(s"Check last validation email for DGCCRF users")
       _ <- validateDGCCRFAccountLastEmailValidation(user)
       _ = logger.debug(s"Successful login for user ${userLogin.login}")
+      token <- getToken(userLogin)(request)
     } yield UserSession(token, user)
 
     eventualUserSession
@@ -76,6 +87,20 @@ class AuthOrchestrator @Inject() (
       }
 
   }
+
+  private def getToken(userLogin: UserLogin)(implicit req: Request[_]): Future[String] = for {
+    loginInfo <- credentialsProvider
+      .authenticate(Credentials(userLogin.login, userLogin.password))
+      .recoverWith {
+        case _: InvalidPasswordException =>
+          Future.failed(InvalidPassword(userLogin.login))
+        case _: IdentityNotFoundException => Future.failed(UserNotFound(userLogin.login))
+        case err =>
+          Future.failed(ServerError("Unexpected error when authenticating user", Some(err)))
+      }
+    authenticator <- silhouette.env.authenticatorService.create(loginInfo)
+    token <- silhouette.env.authenticatorService.init(authenticator)
+  } yield token
 
   private def validateDGCCRFAccountLastEmailValidation(user: User): Future[User] = user.userRole match {
     case UserRole.DGCCRF if needsEmailRevalidation(user) =>

--- a/app/orchestrators/AuthOrchestrator.scala
+++ b/app/orchestrators/AuthOrchestrator.scala
@@ -1,0 +1,111 @@
+package orchestrators
+
+import cats.implicits.catsSyntaxMonadError
+import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
+import controllers.error.AppError.DGCCRFUserEmailValidationExpired
+import controllers.error.AppError.TooMuchAuthAttempts
+import controllers.error.AppError.UserNotFound
+import models.User
+import models.UserLogin
+import models.UserRole
+import repositories.UserRepository
+import utils.silhouette.auth.UserService
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+import cats.syntax.option._
+import cats.instances.future.catsStdInstancesForFuture
+import com.mohiva.play.silhouette.api.LoginInfo
+import config.AppConfigLoader
+import controllers.error.AppError
+import models.token.UserSession
+import orchestrators.AuthOrchestrator.AuthAttemptPeriod
+import orchestrators.AuthOrchestrator.MaxAllowedAuthAttempts
+import play.api.Logger
+
+import java.time.OffsetDateTime
+import java.time.Period
+
+class AuthOrchestrator @Inject() (
+    userService: UserService,
+    userRepository: UserRepository,
+    accessesOrchestrator: AccessesOrchestrator,
+    appConfigLoader: AppConfigLoader
+)(implicit
+    ec: ExecutionContext
+) {
+
+  private val logger: Logger = Logger(this.getClass)
+  private val dgccrfDelayBeforeRevalidation: Period = appConfigLoader.get.token.dgccrfDelayBeforeRevalidation
+
+  def login(userLogin: UserLogin, token: String): Future[UserSession] = {
+
+    val eventualUserSession: Future[UserSession] = for {
+      maybeUser <- userService.retrieve(LoginInfo(CredentialsProvider.ID, userLogin.login))
+      user <- maybeUser.liftTo[Future](UserNotFound(userLogin.login))
+      _ = logger.debug(s"Found user")
+      _ = logger.debug(s"Validate auth attempts count")
+      _ <- validateAuthenticationAttempts(user)
+      _ = logger.debug(s"Check last validation email for DGCCRF users")
+      _ <- validateDGCCRFAccountLastEmailValidation(user)
+      _ = logger.debug(s"Successful login for user ${userLogin.login}")
+    } yield UserSession(token, user)
+
+    eventualUserSession
+      .flatMap { session =>
+        userRepository.saveAuthAttempt(userLogin.login, isSuccess = true).map(_ => session)
+      }
+      .recoverWith {
+        case error: AppError =>
+          userRepository
+            .saveAuthAttempt(userLogin.login, isSuccess = false, failureCause = Some(error.details))
+            .flatMap(_ => Future.failed(error))
+        case error =>
+          userRepository
+            .saveAuthAttempt(
+              userLogin.login,
+              isSuccess = false,
+              failureCause = Some(s"Unexpected error : ${error.getMessage}")
+            )
+            .flatMap(_ => Future.failed(error))
+
+      }
+
+  }
+
+  private def validateDGCCRFAccountLastEmailValidation(user: User): Future[User] = user.userRole match {
+    case UserRole.DGCCRF if needsEmailRevalidation(user) =>
+      accessesOrchestrator
+        .sendEmailValidation(user)
+        .flatMap(_ => throw DGCCRFUserEmailValidationExpired(user.email.value))
+    case _ =>
+      logger.debug(s"No periodic email revalidation needed for the user")
+      Future.successful(user)
+  }
+
+  private def needsEmailRevalidation(user: User) =
+    user.lastEmailValidation
+      .exists(
+        _.isBefore(
+          OffsetDateTime.now
+            .minus(dgccrfDelayBeforeRevalidation)
+        )
+      )
+
+  private def validateAuthenticationAttempts(user: User): Future[User] = for {
+    _ <- userRepository
+      .countAuthAttempts(user.email.value, AuthAttemptPeriod)
+      .ensure(TooMuchAuthAttempts(user.id))(attempts => attempts < MaxAllowedAuthAttempts)
+    _ = logger.debug(s"Auth attempts count check successful")
+  } yield user
+
+}
+
+object AuthOrchestrator {
+  val AuthAttemptPeriod: Duration = 30 minutes
+  val MaxAllowedAuthAttempts: Int = 15
+}

--- a/app/repositories/AuthTokenRepository.scala
+++ b/app/repositories/AuthTokenRepository.scala
@@ -1,6 +1,6 @@
 package repositories
 
-import models.AuthToken
+import models.auth.AuthToken
 import play.api.db.slick.DatabaseConfigProvider
 import slick.jdbc.JdbcProfile
 
@@ -29,7 +29,9 @@ class AuthTokenRepository @Inject() (
   private class AuthTokenTable(tag: Tag) extends Table[AuthToken](tag, "auth_tokens") {
 
     def id = column[UUID]("id", O.PrimaryKey)
+
     def userId = column[UUID]("user_id")
+
     def expiry = column[OffsetDateTime]("expiry")
 
     type AuthTokenData = (UUID, UUID, OffsetDateTime)
@@ -66,4 +68,15 @@ class AuthTokenRepository @Inject() (
       .filter(_.userId === userId)
       .delete
   }
+
+  def findForUserId(userId: UUID): Future[Seq[AuthToken]] = db.run {
+    authTokenTableQuery
+      .filter(_.userId === userId)
+      .result
+  }
+
+  def list(): Future[Seq[AuthToken]] = db.run {
+    authTokenTableQuery.result
+  }
+
 }

--- a/app/repositories/UserRepository.scala
+++ b/app/repositories/UserRepository.scala
@@ -112,6 +112,13 @@ class UserRepository @Inject() (
         .result
     )
 
+  def listAuthAttempts(login: String) = db
+    .run(
+      authAttemptTableQuery
+        .filter(_.login === login)
+        .result
+    )
+
   def saveAuthAttempt(login: String, isSuccess: Boolean, failureCause: Option[String] = None) = {
 
     val authAttempt = AuthAttempt(UUID.randomUUID, login, OffsetDateTime.now, Some(isSuccess), failureCause)

--- a/app/repositories/UserRepository.scala
+++ b/app/repositories/UserRepository.scala
@@ -2,6 +2,7 @@ package repositories
 
 import com.mohiva.play.silhouette.api.util.PasswordHasherRegistry
 import models._
+import models.auth.AuthAttempt
 import play.api.Logger
 import play.api.db.slick.DatabaseConfigProvider
 import repositories.PostgresProfile.api._

--- a/app/repositories/UserRepository.scala
+++ b/app/repositories/UserRepository.scala
@@ -2,18 +2,19 @@ package repositories
 
 import com.mohiva.play.silhouette.api.util.PasswordHasherRegistry
 import models._
+import play.api.Logger
 import play.api.db.slick.DatabaseConfigProvider
 import repositories.PostgresProfile.api._
 import slick.jdbc.JdbcProfile
 import utils.EmailAddress
 
-import java.time.Duration
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 class UserTable(tag: Tag) extends Table[User](tag, "users") {
 
@@ -52,8 +53,10 @@ class AuthAttempTable(tag: Tag) extends Table[AuthAttempt](tag, "auth_attempts")
   def id = column[UUID]("id", O.PrimaryKey)
   def login = column[String]("login")
   def timestamp = column[OffsetDateTime]("timestamp")
+  def isSuccess = column[Option[Boolean]]("is_success")
+  def failureCause = column[Option[String]]("failure_cause")
 
-  def * = (id, login, timestamp) <> (AuthAttempt.tupled, AuthAttempt.unapply)
+  def * = (id, login, timestamp, isSuccess, failureCause) <> (AuthAttempt.tupled, AuthAttempt.unapply)
 }
 
 object UserTables {
@@ -76,6 +79,7 @@ class UserRepository @Inject() (
 )(implicit ec: ExecutionContext) {
 
   private val dbConfig = dbConfigProvider.get[JdbcProfile]
+  val logger: Logger = Logger(this.getClass)
 
   import dbConfig._
 
@@ -103,15 +107,20 @@ class UserRepository @Inject() (
     .run(
       authAttemptTableQuery
         .filter(_.login === login)
-        .filter(_.timestamp >= OffsetDateTime.now.minus(delay))
+        .filter(_.timestamp >= OffsetDateTime.now.minusMinutes(delay.toMinutes))
         .length
         .result
     )
 
-  def saveAuthAttempt(login: String) = db
-    .run(
-      authAttemptTableQuery += AuthAttempt(UUID.randomUUID, login, OffsetDateTime.now)
-    )
+  def saveAuthAttempt(login: String, isSuccess: Boolean, failureCause: Option[String] = None) = {
+
+    val authAttempt = AuthAttempt(UUID.randomUUID, login, OffsetDateTime.now, Some(isSuccess), failureCause)
+    logger.debug(s"Saving auth attempt $authAttempt")
+    db
+      .run(
+        authAttemptTableQuery += AuthAttempt(UUID.randomUUID, login, OffsetDateTime.now, Some(isSuccess), failureCause)
+      )
+  }
 
   def update(user: User): Future[Int] = {
     val queryUser =

--- a/app/services/Email.scala
+++ b/app/services/Email.scala
@@ -1,6 +1,5 @@
 package services
 
-import models.AuthToken
 import models.Company
 import models.EmailValidation
 import models.Event
@@ -9,6 +8,7 @@ import models.ReportFile
 import models.ReportResponse
 import models.Subscription
 import models.User
+import models.auth.AuthToken
 import play.api.libs.mailer.Attachment
 import utils.Constants.Tags
 import utils.EmailAddress

--- a/app/utils/FrontRoute.scala
+++ b/app/utils/FrontRoute.scala
@@ -1,7 +1,7 @@
 package utils
 
 import config.AppConfigLoader
-import models.AuthToken
+import models.auth.AuthToken
 
 import java.net.URI
 import javax.inject.Inject

--- a/app/views/mails/resetPassword.scala.html
+++ b/app/views/mails/resetPassword.scala.html
@@ -1,5 +1,7 @@
 @import utils.FrontRoute
 @import utils.EmailAddress
+@import models.auth.AuthToken
+
 @(user: User, authToken: AuthToken)(implicit frontRoute: FrontRoute, contactAddress: EmailAddress)
 
 @views.html.mails.layout("Votre mot de passe SignalConso") {

--- a/conf/evolutions/default/69.sql
+++ b/conf/evolutions/default/69.sql
@@ -1,0 +1,9 @@
+-- !Ups
+
+ALTER TABLE auth_attempts ADD COLUMN is_success BOOLEAN;
+ALTER TABLE auth_attempts ADD COLUMN failure_cause VARCHAR;
+
+-- !Downs
+
+ALTER TABLE auth_attempts DROP COLUMN is_success;
+ALTER TABLE auth_attempts DROP COLUMN failure_cause;

--- a/test/controllers/AuthControllerSpec.scala
+++ b/test/controllers/AuthControllerSpec.scala
@@ -1,0 +1,148 @@
+package controllers
+
+import com.google.inject.AbstractModule
+import com.mohiva.play.silhouette.api.Environment
+import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.api.util.PasswordHasherRegistry
+import com.mohiva.play.silhouette.api.util.PasswordInfo
+import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
+import com.mohiva.play.silhouette.password.BCryptPasswordHasher
+import com.mohiva.play.silhouette.test.FakeEnvironment
+import controllers.error.ErrorPayload
+import controllers.error.AppError.MalformedBody
+import controllers.error.ErrorPayload.AuthenticationErrorPayload
+import models._
+import models.token.TokenKind.CompanyJoin
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
+import repositories._
+import utils.AppSpec
+import utils.Fixtures
+import utils.silhouette.auth.AuthEnv
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class AuthControllerSpec(implicit ee: ExecutionEnv)
+    extends Specification
+    with AppSpec
+    with Results
+    with FutureMatchers {
+
+  val identity = Fixtures.genAdminUser.sample.get
+    .copy(password = PasswordInfo(BCryptPasswordHasher.ID, password = "test", salt = Some("SignalConso")).password)
+  val identLoginInfo = LoginInfo(CredentialsProvider.ID, identity.email.value)
+  implicit val env: Environment[AuthEnv] = new FakeEnvironment[AuthEnv](Seq(identLoginInfo -> identity))
+
+  lazy val userRepository = app.injector.instanceOf[UserRepository]
+  lazy val passwordHasherRegistry = app.injector.instanceOf[PasswordHasherRegistry]
+  lazy val companyRepository = app.injector.instanceOf[CompanyRepository]
+  lazy val accessTokenRepository = app.injector.instanceOf[AccessTokenRepository]
+
+  override def configureFakeModule(): AbstractModule =
+    new FakeModule
+
+  class FakeModule extends AppFakeModule {
+    override def configure() = {
+      super.configure
+      bind[Environment[AuthEnv]].toInstance(env)
+    }
+  }
+
+  val proUser = Fixtures.genProUser.sample.get
+  val company = Fixtures.genCompany.sample.get
+  override def setupData() =
+    Await.result(
+      for {
+        _ <- userRepository.create(proUser)
+        _ <- userRepository.create(identity)
+        _ <- companyRepository.getOrCreate(company.siret, company)
+        _ <- accessTokenRepository
+          .createToken(CompanyJoin, "123456", None, Some(company.id), Some(AccessLevel.ADMIN), None)
+      } yield (),
+      Duration.Inf
+    )
+
+  "AccountController" should {
+    "login" should {
+      "fail on invalid body" in {
+
+        val jsonBody = Json.obj("newPassword" -> "password", "oldPassword" -> "password")
+
+        val request = FakeRequest(POST, routes.AuthController.authenticate().toString)
+          //            .withAuthenticator[AuthEnv](identLoginInfo)
+          .withJsonBody(jsonBody)
+
+        val result = route(app, request).get
+
+        Helpers.status(result) must beEqualTo(BAD_REQUEST)
+        Helpers.contentAsJson(result) must beEqualTo(
+          Json.toJson(ErrorPayload(MalformedBody))
+        )
+      }
+
+      "fail on invalid password " in {
+
+        val jsonBody = Json.obj("login" -> proUser.email, "password" -> "password")
+
+        val request = FakeRequest(POST, routes.AuthController.authenticate().toString)
+          .withJsonBody(jsonBody)
+
+        val result = route(app, request).get
+
+        Helpers.status(result) must beEqualTo(UNAUTHORIZED)
+        Helpers.contentAsJson(result) must beEqualTo(
+          Json.toJson(AuthenticationErrorPayload)
+        )
+      }
+
+      "fail on unknown user " in {
+
+        val jsonBody = Json.obj("login" -> "login", "password" -> "password")
+
+        val request = FakeRequest(POST, routes.AuthController.authenticate().toString)
+          .withJsonBody(jsonBody)
+
+        val result = route(app, request).get
+
+        Helpers.status(result) must beEqualTo(UNAUTHORIZED)
+        Helpers.contentAsJson(result) must beEqualTo(
+          Json.toJson(AuthenticationErrorPayload)
+        )
+      }
+
+    }
+
+    "success on known user " in {
+
+      val jsonBody = Json.obj("login" -> identity.email, "password" -> "test")
+
+      val request = FakeRequest(POST, routes.AuthController.authenticate().toString)
+        .withJsonBody(jsonBody)
+
+      val result = route(app, request).get
+
+      Helpers.status(result) must beEqualTo(UNAUTHORIZED)
+      Helpers.contentAsJson(result) must beEqualTo(
+        Json.toJson(AuthenticationErrorPayload)
+      )
+    }
+
+  }
+
+//
+//      "send a DGCCRF invitation" in {
+//        val request = FakeRequest(POST, routes.AccountController.sendDGCCRFInvitation().toString)
+//          .withAuthenticator[AuthEnv](identLoginInfo)
+//          .withJsonBody(Json.obj("email" -> "user@dgccrf.gouv.fr"))
+//
+//        val result = route(app, request).get
+//        Helpers.status(result) must beEqualTo(200)
+//      }
+
+}

--- a/test/controllers/AuthControllerSpec.scala
+++ b/test/controllers/AuthControllerSpec.scala
@@ -3,7 +3,6 @@ package controllers
 import com.google.inject.AbstractModule
 import com.mohiva.play.silhouette.api.Environment
 import com.mohiva.play.silhouette.api.LoginInfo
-import com.mohiva.play.silhouette.api.Silhouette
 import com.mohiva.play.silhouette.api.util.PasswordHasherRegistry
 import com.mohiva.play.silhouette.api.util.PasswordInfo
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
@@ -12,9 +11,11 @@ import com.mohiva.play.silhouette.test.FakeEnvironment
 import controllers.error.ErrorPayload
 import controllers.error.AppError.InvalidPassword
 import controllers.error.AppError.MalformedBody
+import controllers.error.AppError.TokenNotFoundOrInvalid
 import controllers.error.AppError.UserNotFound
 import controllers.error.ErrorPayload.AuthenticationErrorPayload
 import models._
+import models.auth.AuthToken
 import models.token.TokenKind.CompanyJoin
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
@@ -28,6 +29,8 @@ import utils.AppSpec
 import utils.Fixtures
 import utils.silhouette.auth.AuthEnv
 
+import java.time.OffsetDateTime
+import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -49,7 +52,7 @@ class AuthControllerSpec(implicit ee: ExecutionEnv)
   lazy val passwordHasherRegistry = app.injector.instanceOf[PasswordHasherRegistry]
   lazy val companyRepository = app.injector.instanceOf[CompanyRepository]
   lazy val accessTokenRepository = app.injector.instanceOf[AccessTokenRepository]
-  lazy val silhouette = app.injector.instanceOf[Silhouette[AuthEnv]]
+  lazy val authTokenRepository = app.injector.instanceOf[AuthTokenRepository]
 
   override def configureFakeModule(): AbstractModule =
     new FakeModule
@@ -168,6 +171,118 @@ class AuthControllerSpec(implicit ee: ExecutionEnv)
       authAttempts.headOption.flatMap(_.isSuccess) shouldEqual (Some(true))
       authAttempts.headOption.flatMap(_.failureCause) shouldEqual None
 
+    }
+  }
+
+  "forgot password" should {
+
+    "fail on invalid body" in {
+
+      val jsonBody = Json.obj("password" -> "password")
+
+      val request = FakeRequest(POST, routes.AuthController.forgotPassword().toString)
+        .withJsonBody(jsonBody)
+
+      val result = route(app, request).get
+
+      Helpers.status(result) must beEqualTo(BAD_REQUEST)
+      Helpers.contentAsJson(result) must beEqualTo(
+        Json.toJson(ErrorPayload(MalformedBody))
+      )
+    }
+
+    "not create an auth token when user unknown" in {
+
+      val login = "unknown"
+      val jsonBody = Json.obj("login" -> login)
+
+      val request = FakeRequest(POST, routes.AuthController.forgotPassword().toString)
+        .withJsonBody(jsonBody)
+
+      val result = for {
+        authTokensBefore <- authTokenRepository.list()
+        res <- route(app, request).get
+        authTokensAfter <- authTokenRepository.list()
+      } yield (res, authTokensBefore.diff(authTokensAfter))
+
+      Helpers.status(result.map(_._1)) must beEqualTo(OK)
+      val authTokenCreated = Await.result(result.map(_._2), Duration.Inf)
+      authTokenCreated.length shouldEqual 0
+
+    }
+
+    "successfully create an auth token" in {
+
+      val login = identity.email.value
+      val jsonBody = Json.obj("login" -> login)
+
+      val request = FakeRequest(POST, routes.AuthController.forgotPassword().toString)
+        .withJsonBody(jsonBody)
+
+      val result = for {
+        res <- route(app, request).get
+        authToken <- authTokenRepository.findForUserId(identity.id)
+      } yield (res, authToken)
+
+      Helpers.status(result.map(_._1)) must beEqualTo(OK)
+      val authToken = Await.result(result.map(_._2), Duration.Inf)
+      authToken.length shouldEqual 1
+
+    }
+
+  }
+
+  "reset password" should {
+
+    "fail on invalid body" in {
+
+      val jsonBody = Json.obj("login" -> "test")
+
+      val request = FakeRequest(POST, routes.AuthController.resetPassword(UUID.randomUUID()).toString)
+        .withJsonBody(jsonBody)
+
+      val result = route(app, request).get
+
+      Helpers.status(result) must beEqualTo(BAD_REQUEST)
+      Helpers.contentAsJson(result) must beEqualTo(
+        Json.toJson(ErrorPayload(MalformedBody))
+      )
+    }
+
+    "fail on token expired" in {
+
+      val tokenId = UUID.randomUUID()
+      val expiredToken = AuthToken(tokenId, UUID.randomUUID(), OffsetDateTime.now().minusMonths(10))
+      val jsonBody = Json.obj("password" -> "test")
+
+      val request = FakeRequest(POST, routes.AuthController.resetPassword(tokenId).toString)
+        .withJsonBody(jsonBody)
+
+      val result = for {
+        authToken <- authTokenRepository.create(expiredToken)
+        res <- route(app, request).get
+      } yield (res, authToken)
+
+      Helpers.status(result.map(_._1)) must beEqualTo(NOT_FOUND)
+      Helpers.contentAsJson(result.map(_._1)) must beEqualTo(
+        Json.toJson(ErrorPayload(TokenNotFoundOrInvalid(tokenId)))
+      )
+    }
+
+    "fail on token not found" in {
+
+      val tokenId = UUID.randomUUID()
+      val jsonBody = Json.obj("password" -> "test")
+
+      val request = FakeRequest(POST, routes.AuthController.resetPassword(tokenId).toString)
+        .withJsonBody(jsonBody)
+
+      val result = route(app, request).get
+
+      Helpers.status(result) must beEqualTo(NOT_FOUND)
+      Helpers.contentAsJson(result) must beEqualTo(
+        Json.toJson(ErrorPayload(TokenNotFoundOrInvalid(tokenId)))
+      )
     }
 
   }


### PR DESCRIPTION
Add meaningful error details on failed auth attempts to facilitate debugging auth issues.
Return better error messages on auth.
Add test case for authentication.