### PR TITLE
TRELLO-1173 use OffsetDateTime for start/end (#1135)

### DIFF
--- a/app/controllers/ReportToExternalController.scala
+++ b/app/controllers/ReportToExternalController.scala
@@ -59,8 +59,8 @@ class ReportToExternalController(
     val qs = new QueryStringMapper(request.queryString)
     val filter = ReportFilter(
       siretSirenList = qs.string("siret").map(List(_)).getOrElse(List()),
-      start = qs.localDate("start"),
-      end = qs.localDate("end"),
+      start = qs.timeWithLocalDateRetrocompatStartOfDay("start"),
+      end = qs.timeWithLocalDateRetrocompatEndOfDay("end"),
       withTags = qs.seq("tags").map(ReportTag.withName)
     )
 
@@ -84,8 +84,8 @@ class ReportToExternalController(
     val qs = new QueryStringMapper(request.queryString)
     val filter = ReportFilter(
       siretSirenList = qs.string("siret").map(List(_)).getOrElse(List()),
-      start = qs.localDate("start"),
-      end = qs.localDate("end"),
+      start = qs.timeWithLocalDateRetrocompatStartOfDay("start"),
+      end = qs.timeWithLocalDateRetrocompatEndOfDay("end"),
       withTags = qs.seq("tags").map(ReportTag.withName)
     )
     val offset = qs.long("offset")
@@ -114,11 +114,12 @@ class ReportToExternalController(
     val qs = new QueryStringMapper(request.queryString)
     val filter = ReportFilter(
       siretSirenList = List(siret),
-      start = qs.localDate("start"),
-      end = qs.localDate("end")
+      start = qs.timeWithLocalDateRetrocompatStartOfDay("start"),
+      end = qs.timeWithLocalDateRetrocompatEndOfDay("end")
     )
     for {
       reports <- reportRepository.getReports(filter, Some(0), Some(1000000))
     } yield Ok(Json.toJson(reports.entities.map(ReportToExternal.fromReport)))
   }
+
 }

--- a/app/models/report/ReportFilter.scala
+++ b/app/models/report/ReportFilter.scala
@@ -6,9 +6,9 @@ import models.UserRole.DGCCRF
 import models.report.ReportTag
 import utils.QueryStringMapper
 
-import java.time.LocalDate
 import java.util.UUID
 import scala.util.Try
+import java.time.OffsetDateTime
 
 case class ReportFilter(
     departments: Seq[String] = Seq.empty,
@@ -19,8 +19,8 @@ case class ReportFilter(
     companyIds: Seq[UUID] = Seq.empty,
     companyName: Option[String] = None,
     companyCountries: Seq[String] = Seq.empty,
-    start: Option[LocalDate] = None,
-    end: Option[LocalDate] = None,
+    start: Option[OffsetDateTime] = None,
+    end: Option[OffsetDateTime] = None,
     category: Option[String] = None,
     status: Seq[ReportStatus] = Seq.empty,
     details: Option[String] = None,
@@ -47,8 +47,9 @@ object ReportFilter {
       siretSirenList = mapper.seq("siretSirenList"),
       companyName = mapper.string("companyName"),
       companyCountries = mapper.seq("companyCountries"),
-      start = mapper.localDate("start"),
-      end = mapper.localDate("end"),
+      // temporary retrocompat, so we can mep the API safely
+      start = mapper.timeWithLocalDateRetrocompatStartOfDay("start"),
+      end = mapper.timeWithLocalDateRetrocompatEndOfDay("end"),
       category = mapper.string("category"),
       companyIds = mapper.seq("companyIds").map(UUID.fromString),
       status = ReportStatus.filterByUserRole(

--- a/app/repositories/report/ReportRepository.scala
+++ b/app/repositories/report/ReportRepository.scala
@@ -351,10 +351,10 @@ object ReportRepository {
           .getOrElse(false)
       }
       .filterOpt(filter.start) { case (table, start) =>
-        table.creationDate >= ZonedDateTime.of(start, LocalTime.MIN, ZoneOffset.UTC.normalized()).toOffsetDateTime
+        table.creationDate >= start
       }
       .filterOpt(filter.end) { case (table, end) =>
-        table.creationDate < ZonedDateTime.of(end, LocalTime.MAX, ZoneOffset.UTC.normalized()).toOffsetDateTime
+        table.creationDate <= end
       }
       .filterOpt(filter.category) { case (table, category) =>
         table.category === category

--- a/app/utils/DateUtils.scala
+++ b/app/utils/DateUtils.scala
@@ -2,16 +2,16 @@ package utils
 
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.time.OffsetDateTime
+import java.time.ZoneId
 
 object DateUtils {
 
   val DATE_FORMAT = "yyyy-MM-dd"
   val FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT)
-  val TIME_FORMAT = "yyyy-MM-dd HH:mm:ss"
-  val TIME_FORMATTER = DateTimeFormatter.ofPattern(TIME_FORMAT)
+  val TIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
   def parseDate(source: Option[String]): Option[LocalDate] =
     try source.map(s => LocalDate.parse(s, FORMATTER))
@@ -19,13 +19,10 @@ object DateUtils {
       case _: DateTimeParseException => None
     }
 
-  def formatTime(time: LocalDateTime) =
-    time.format(TIME_FORMATTER)
-
-  def formatTime(time: Option[LocalDateTime]) =
-    time match {
-      case None        => ""
-      case Some(value) => value.format(TIME_FORMATTER)
+  def parseTime(source: Option[String]): Option[OffsetDateTime] =
+    try source.map(s => OffsetDateTime.parse(s, TIME_FORMATTER))
+    catch {
+      case _: DateTimeParseException => None
     }
 
   def withDayOfWeek(date: LocalDate, day: DayOfWeek) = {
@@ -34,5 +31,11 @@ object DateUtils {
       innerDate = innerDate.minusDays(1)
     innerDate
   }
+
+  def frenchFormatDate(d: OffsetDateTime, zone: ZoneId) =
+    d.atZoneSameInstant(zone).format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+
+  def frenchFormatDateAndTime(d: OffsetDateTime, zone: ZoneId) =
+    d.atZoneSameInstant(zone).format(DateTimeFormatter.ofPattern("dd/MM/yyyy à HH:mm:ss"))
 
 }

--- a/app/utils/QueryStringMapper.scala
+++ b/app/utils/QueryStringMapper.scala
@@ -3,6 +3,10 @@ package utils
 import models.extractUUID
 
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.UUID
 
 class QueryStringMapper(q: Map[String, Seq[String]]) {
@@ -19,9 +23,26 @@ class QueryStringMapper(q: Map[String, Seq[String]]) {
 
   def localDate(k: String): Option[LocalDate] = DateUtils.parseDate(string(k))
 
+  def time(k: String): Option[OffsetDateTime] = DateUtils.parseTime(string(k))
+
+  private def timeWithLocalDateRetrocompat(k: String, assumedLocalTime: LocalTime): Option[OffsetDateTime] =
+    time(k).orElse(localDate(k).map(ld => OffsetDateTime.of(ld, assumedLocalTime, ZoneOffset.UTC)))
+
+  // Allows the legacy format YYYY-MM-DD, assuming it means YYYY-MM-DDT00:00:00.000Z
+  def timeWithLocalDateRetrocompatStartOfDay(k: String) =
+    timeWithLocalDateRetrocompat(k, LocalTime.MIN)
+
+  // Allows the legacy format YYYY-MM-DD, assuming it means YYYY-MM-DDT23:59:59.999Z
+  def timeWithLocalDateRetrocompatEndOfDay(k: String) =
+    timeWithLocalDateRetrocompat(k, LocalTime.MAX)
+
   def boolean(k: String): Option[Boolean] = string(k) match {
     case Some("true")  => Some(true)
     case Some("false") => Some(false)
     case _             => None
   }
+
+  def timeZone(k: String): Option[ZoneId] =
+    string(k).map(ZoneId.of)
+
 }

--- a/test/models/ReportFilterTest.scala
+++ b/test/models/ReportFilterTest.scala
@@ -9,9 +9,11 @@ import models.UserRole.Professionnel
 import org.specs2.mutable.Specification
 import utils.DateUtils
 
-import java.time.LocalDate
 import java.util.UUID
 import scala.util.Success
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class ReportFilterTest extends Specification {
 
@@ -46,8 +48,8 @@ class ReportFilterTest extends Specification {
         companyIds = Seq(UUID.randomUUID(), UUID.randomUUID()),
         companyName = Some("Company_Name"),
         companyCountries = Seq("FR", "EN"),
-        start = Some(LocalDate.of(2021, 10, 10)),
-        end = Some(LocalDate.of(2021, 12, 10)),
+        start = Some(OffsetDateTime.of(LocalDateTime.of(2021, 10, 10, 19, 30, 40), ZoneOffset.of("+02:00"))),
+        end = Some(OffsetDateTime.of(LocalDateTime.of(2021, 12, 10, 7, 0, 25), ZoneOffset.of("-05:00"))),
         category = Some("Categorie"),
         status = ReportStatus.statusVisibleByPro,
         details = Some("My Details"),
@@ -69,8 +71,8 @@ class ReportFilterTest extends Specification {
         "siretSirenList" -> expectedReportFilter.siretSirenList,
         "companyName" -> expectedReportFilter.companyName.toSeq,
         "companyCountries" -> expectedReportFilter.companyCountries,
-        "start" -> expectedReportFilter.start.toSeq.map(_.format(DateUtils.FORMATTER)),
-        "end" -> expectedReportFilter.end.toSeq.map(_.format(DateUtils.FORMATTER)),
+        "start" -> expectedReportFilter.start.toSeq.map(_.format(DateUtils.TIME_FORMATTER)),
+        "end" -> expectedReportFilter.end.toSeq.map(_.format(DateUtils.TIME_FORMATTER)),
         "category" -> expectedReportFilter.category.toSeq,
         "companyIds" -> expectedReportFilter.companyIds.map(_.toString),
         "status" -> expectedReportFilter.status.map(_.entryName),

--- a/test/tasks/report/DailyReportNotificationTaskSpec.scala
+++ b/test/tasks/report/DailyReportNotificationTaskSpec.scala
@@ -8,16 +8,16 @@ import org.specs2.matcher.FutureMatchers
 import models.report.ReportTag
 import utils._
 
-import java.time.LocalDate
 import java.time.Period
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import java.time.OffsetDateTime
 
 class DailyReportNotification(implicit ee: ExecutionEnv) extends DailyReportNotificationTaskSpec {
   override def is =
     s2"""
          When daily reportNotificationTask task run                                      ${step {
-        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningDate, Period.ofDays(1)), Duration.Inf)
+        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningTime, Period.ofDays(1)), Duration.Inf)
       }}
          And a mail is sent to the user subscribed by category                           ${mailMustHaveBeenSent(
         Seq(covidEmail),
@@ -62,7 +62,8 @@ abstract class DailyReportNotificationTaskSpec(implicit ee: ExecutionEnv)
 
   implicit val ec = ee.executionContext
 
-  val runningDate = LocalDate.now.plusDays(1)
+  val runningTime = OffsetDateTime.now.plusDays(1)
+  val runningDate = runningTime.toLocalDate()
 
   val covidDept = "01"
   val tagDept = "02"

--- a/test/tasks/report/NoReportNotificationTaskSpec.scala
+++ b/test/tasks/report/NoReportNotificationTaskSpec.scala
@@ -9,16 +9,16 @@ import org.specs2.matcher.FutureMatchers
 import utils._
 import play.api.libs.mailer.Attachment
 
-import java.time.LocalDate
 import java.time.Period
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import java.time.OffsetDateTime
 
 class NoReportNotification(implicit ee: ExecutionEnv) extends NoReportNotificationTaskSpec {
   override def is =
     s2"""
          When daily reportNotificationTask task run                                      ${step {
-        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningDate, Period.ofDays(1)), Duration.Inf)
+        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningTime, Period.ofDays(1)), Duration.Inf)
       }}
          And no email are sent to any users                           ${mailMustNotHaveBeenSent()}
     """
@@ -45,8 +45,8 @@ abstract class NoReportNotificationTaskSpec(implicit ee: ExecutionEnv)
 
   implicit val ec = ee.executionContext
 
-  val runningDate = LocalDate.now.plusDays(1)
-
+  val runningTime = OffsetDateTime.now.plusDays(1)
+  val runningDate = runningTime.toLocalDate()
   val covidDept = "01"
   val tagDept = "02"
 

--- a/test/tasks/report/ReportTagFilterNotificationTaskSpec.scala
+++ b/test/tasks/report/ReportTagFilterNotificationTaskSpec.scala
@@ -7,17 +7,17 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import utils._
 
-import java.time.LocalDate
-import java.time.Period
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import java.time.OffsetDateTime
+import java.time.Period
 
 class DailyReporFilterWithTagNotification(implicit ee: ExecutionEnv) extends ReportTagFilterNotificationTaskSpec {
 
   override def is =
     s2"""
          When daily reportNotificationTask task run                                      ${step {
-        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningDate, Period.ofDays(1)), Duration.Inf)
+        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningTime, Period.ofDays(1)), Duration.Inf)
       }}
          And a mail is sent to the user subscribed by tag                                ${mailMustHaveBeenSent(
         Seq(tagEmail),
@@ -34,7 +34,7 @@ class DailyReportFilterWithoutTagNotification(implicit ee: ExecutionEnv) extends
   override def is =
     s2"""
          When daily reportNotificationTask task run                                      ${step {
-        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningDate, Period.ofDays(1)), Duration.Inf)
+        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningTime, Period.ofDays(1)), Duration.Inf)
       }}
          And a mail is sent to the user subscribed without tag                                ${mailMustHaveBeenSent(
         Seq(noTagEmail),
@@ -67,8 +67,8 @@ abstract class ReportTagFilterNotificationTaskSpec(implicit ee: ExecutionEnv)
 
   implicit val ec = ee.executionContext
 
-  val runningDate = LocalDate.now.plusDays(1)
-
+  val runningTime = OffsetDateTime.now.plusDays(1)
+  val runningDate = runningTime.toLocalDate()
   val tagDept = "02"
 
   val tagEmail = Fixtures.genEmailAddress("tag", "abo").sample.get

--- a/test/tasks/report/WeeklyReportNotificationTaskSpec.scala
+++ b/test/tasks/report/WeeklyReportNotificationTaskSpec.scala
@@ -6,7 +6,6 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import utils._
 
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.Period
 import scala.concurrent.Await
@@ -16,7 +15,7 @@ class WeeklyReportNotification(implicit ee: ExecutionEnv) extends WeeklyReportNo
   override def is =
     s2"""
       When weekly reportNotificationTask task run               ${step {
-        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningDate, Period.ofDays(7)), Duration.Inf)
+        Await.result(reportNotificationTask.runPeriodicNotificationTask(runningTime, Period.ofDays(7)), Duration.Inf)
       }}
 
     A mail is sent to the subscribed user                     ${mailMustHaveBeenSent(
@@ -65,7 +64,8 @@ abstract class WeeklyReportNotificationTaskSpec(implicit ee: ExecutionEnv)
 
   implicit val ec = ee.executionContext
 
-  val runningDate = LocalDate.now.plusDays(1)
+  val runningTime = OffsetDateTime.now.plusDays(1)
+  val runningDate = runningTime.toLocalDate()
 
   val department1 = "87"
   val department2 = "19"


### PR DESCRIPTION
Les params start/end utilisent maintenant un format datetime complet ISO 8601, pour corriger des petites incohérences liées à la timezone.
Avec rétrocompatibilité sur l'ancien format, notamment pour les api ouvertes à l'extérieur.

Ce commit fixe également un bug dans l'envoi de mail pour les abonnements : les dates de début/fin utilisées étaient légèrement incorrectes et donc certains signalements devaient être envoyés plusieurs fois à la même personne deux jours de suite.