### PR TITLE
TRELLO-1473 fix courrier activation si 0 reports

### DIFF
--- a/app/controllers/CompanyController.scala
+++ b/app/controllers/CompanyController.scala
@@ -157,7 +157,7 @@ class CompanyController(
       events: List[Event],
       activationKey: String
   ) = {
-    val lastContact = events
+    val lastContactLocalDate = events
       .filter(e =>
         e.creationDate.isAfter(OffsetDateTime.now(ZoneOffset.UTC).minus(noAccessReadingDelay))
           && List(ActionEvent.POST_ACCOUNT_ACTIVATION_DOC, ActionEvent.EMAIL_PRO_REMIND_NO_READING).contains(e.action)
@@ -165,21 +165,29 @@ class CompanyController(
       .sortBy(_.creationDate)
       .reverse
       .headOption
+      .map(_.creationDate.toLocalDate)
+
     val report = reports.sortBy(_.creationDate).reverse.headOption
-    if (lastContact.isDefined)
-      views.html.pdfs.accountActivationReminder(
-        company,
-        lastContact.map(_.creationDate).getOrElse(company.creationDate).toLocalDate,
-        report.map(_.creationDate).getOrElse(company.creationDate).toLocalDate.plus(noAccessReadingDelay),
-        activationKey
-      )(frontRoute = frontRoute, contactAddress = contactAddress)
-    else
-      views.html.pdfs.accountActivation(
-        company,
-        report.map(_.creationDate).getOrElse(company.creationDate).toLocalDate,
-        report.map(_.creationDate).getOrElse(company.creationDate).toLocalDate.plus(noAccessReadingDelay),
-        activationKey
-      )(frontRoute = frontRoute, contactAddress = contactAddress)
+    val reportCreationLocalDate = report.map(_.creationDate.toLocalDate)
+    val reportExpirationLocalDate = report.map(_.creationDate.plus(noAccessReadingDelay).toLocalDate)
+
+    lastContactLocalDate
+      .map { lastContact =>
+        views.html.pdfs.accountActivationReminder(
+          company,
+          lastContact,
+          reportExpirationLocalDate,
+          activationKey
+        )(frontRoute = frontRoute, contactAddress = contactAddress)
+      }
+      .getOrElse {
+        views.html.pdfs.accountActivation(
+          company,
+          reportCreationLocalDate,
+          reportExpirationLocalDate,
+          activationKey
+        )(frontRoute = frontRoute, contactAddress = contactAddress)
+      }
   }
 
   def confirmContactByPostOnCompanyList() = SecuredAction(WithRole(UserRole.Admin)).async(parse.json) {

--- a/app/views/pdfs/accountActivation.scala.html
+++ b/app/views/pdfs/accountActivation.scala.html
@@ -2,7 +2,12 @@
 @import utils.FrontRoute
 @import utils.FrontRoute
 
-@(company: Company, creationDate: java.time.LocalDate, expirationDate: java.time.LocalDate, code: String)(implicit frontRoute: FrontRoute, contactAddress: EmailAddress)
+@(
+    company: Company,
+    reportCreationDate: Option[java.time.LocalDate],
+    reportExpirationDate: Option[java.time.LocalDate],
+    code: String
+)(implicit frontRoute: FrontRoute, contactAddress: EmailAddress)
 
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -43,7 +48,11 @@
             <div class="content mt-3">
 
                 <p>
-                    Objet : réception d’un signalement à propos de votre entreprise par le biais de SignalConso
+                    @reportCreationDate.map{ date =>
+                        Objet : réception d’un signalement à propos de votre entreprise par le biais de SignalConso
+                    }.getOrElse {
+                        Objet : réception de signalements à propos de votre entreprise par le biais de SignalConso
+                    }
                 </p>
 
                 <p class="mt-3">
@@ -62,7 +71,11 @@
                 </p>
 
                 <p class="text-bold">
-                    Nous avons reçu un signalement le @creationDate.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")) pour l’entreprise :
+                @reportCreationDate.map{date =>
+                    Nous avons reçu un signalement le @date.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")) pour l’entreprise :
+                }.getOrElse {
+                    Un compte a été créé sur SignalConso pour l’entreprise :
+                }
                 </p>
 
                 <p class="text-center text-bold">
@@ -70,7 +83,7 @@
                 </p>
 
                 <p class="mt-3">
-                    Pour connaitre ce signalement, rendez-vous sur @frontRoute.dashboard.activation avec :
+                    Pour le consulter, rendez-vous sur @frontRoute.dashboard.activation avec :
                 </p>
 
                 <p class="text-center text-bold">
@@ -79,9 +92,11 @@
                     Votre Code d’activation : @code
                 </p>
 
-                <p class="mt-3">
-                    Vous avez jusqu'au @expirationDate.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")) pour activer votre espace professionnel et consulter le signalement. Passé ce délai, vous pourrez toujours le lire mais ne pourrez plus y répondre. Les enquêteurs de la DGCCRF et le consommateur seront informés que vous n'avez pas souhaité prendre connaissance du signalement.
-                </p>
+                @reportExpirationDate.map{date =>
+                    <p class="mt-3">
+                        Vous avez jusqu'au @date.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")) pour activer votre espace professionnel et consulter le signalement. Passé ce délai, vous pourrez toujours le lire mais ne pourrez plus y répondre. Les enquêteurs de la DGCCRF et le consommateur seront informés que vous n'avez pas souhaité prendre connaissance du signalement.
+                    </p>
+                }
 
                 <p>
                     Ce nouveau service public est facultatif et gratuit. À travers SignalConso, notre objectif est d’établir un rapport de confiance

--- a/app/views/pdfs/accountActivationReminder.scala.html
+++ b/app/views/pdfs/accountActivationReminder.scala.html
@@ -1,8 +1,12 @@
 @import utils.EmailAddress
 @import utils.FrontRoute
 
-@(company: Company, creationDate: java.time.LocalDate, expirationDate: java.time.LocalDate, code: String)(implicit frontRoute: FrontRoute, contactAddress: EmailAddress)
-
+@(
+    company: Company,
+    lastContactDate: java.time.LocalDate,
+    reportExpirationDate: Option[java.time.LocalDate],
+    code: String
+)(implicit frontRoute: FrontRoute, contactAddress: EmailAddress)
 
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -43,7 +47,11 @@
             <div class="content mt-3">
 
                 <p>
-                    Objet : réception d’un signalement à propos de votre entreprise par le biais de SignalConso
+                    @reportExpirationDate.map{ date =>
+                        Objet : réception d’un signalement à propos de votre entreprise par le biais de SignalConso
+                    }.getOrElse {
+                        Objet : réception de signalements à propos de votre entreprise par le biais de SignalConso
+                    }
                 </p>
 
                 <p class="mt-3">
@@ -58,7 +66,7 @@
                 </p>
 
                 <p>
-                    <strong>Nous vous avons adressé un courrier le @creationDate.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy"))</strong>
+                    <strong>Nous vous avons adressé un courrier le @lastContactDate.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy"))</strong>
                     vous indiquant que nous avions reçu un signalement sur votre entreprise
                 </p>
 
@@ -71,8 +79,11 @@
                 </p>
 
                 <p>
-                    Vous avez jusqu’au @expirationDate.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")) pour activer votre espace professionnel
-                    et consulter le signalement.
+                    Vous avez @reportExpirationDate.map { date =>
+                        jusqu’au @date.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+                    }.getOrElse {
+                        un temps limité
+                    } pour activer votre espace professionnel et consulter le signalement.
                     Passé ce délai, vous pourrez toujours le lire mais vous ne pourrez plus y répondre.
                     Les enquêteurs de la <b>DGCCRF</b> et le consommateur seront informés que vous n’avez pas souhaité prendre connaissance du signalement.
                 </p>


### PR DESCRIPTION
It is technically possible to send the activation letter to a company with 0 ongoing reports Adjust the wordings for that special case, instead of using the company creation date.