### PR TITLE
Rework emails test tools

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -131,13 +131,13 @@ class AdminController(
     ProNewCompaniesAccesses,
     ProResponseAcknowledgment,
     ProResponseAcknowledgmentOnAdminCompletion,
-    ProNewReportNotification
+    ProNewReportNotification,
+    ProReportReOpeningNotification
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
-    "pro.report_reopening_notification" -> (recipient => ProReportReOpeningNotification(List(recipient), genReport)),
     "pro.reports_transmitted_reminder" -> (recipient => {
       val report1 = genReport
       val report2 = genReport.copy(companyId = report1.companyId)

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -42,7 +42,6 @@ import utils.Constants.EventType
 import utils._
 
 import java.time.OffsetDateTime
-import java.time.Period
 import java.util.Locale
 import java.util.UUID
 import scala.concurrent.ExecutionContext
@@ -133,23 +132,13 @@ class AdminController(
     ProResponseAcknowledgmentOnAdminCompletion,
     ProNewReportNotification,
     ProReportReOpeningNotification,
-    ProReportsReadReminder
+    ProReportsReadReminder,
+    ProReportsUnreadReminder
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
-    "pro.reports_unread_reminder" -> (recipient => {
-      val report1 = genReport
-      val report2 = genReport.copy(companyId = report1.companyId)
-      val report3 = genReport.copy(companyId = report1.companyId, expirationDate = OffsetDateTime.now().plusDays(5))
-
-      ProReportsUnreadReminder(
-        List(recipient),
-        List(report1, report2, report3),
-        Period.ofDays(7)
-      )
-    }),
     "pro.report_assignement_to_other" -> (recipient =>
       ProReportAssignedNotification(
         report = genReport,

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -132,22 +132,13 @@ class AdminController(
     ProResponseAcknowledgment,
     ProResponseAcknowledgmentOnAdminCompletion,
     ProNewReportNotification,
-    ProReportReOpeningNotification
+    ProReportReOpeningNotification,
+    ProReportsReadReminder
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
-    "pro.reports_transmitted_reminder" -> (recipient => {
-      val report1 = genReport
-      val report2 = genReport.copy(companyId = report1.companyId)
-      val report3 = genReport.copy(companyId = report1.companyId, expirationDate = OffsetDateTime.now().plusDays(5))
-      ProReportsReadReminder(
-        List(recipient),
-        List(report1, report2, report3),
-        Period.ofDays(7)
-      )
-    }),
     "pro.reports_unread_reminder" -> (recipient => {
       val report1 = genReport
       val report2 = genReport.copy(companyId = report1.companyId)

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -44,6 +44,8 @@ import scala.concurrent.duration._
 import services.emails.EmailsExamplesUtils._
 import services.emails.Email
 import services.emails.EmailDefinition
+import services.emails.EmailDefinitionsAdmin.AdminAccessLink
+import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.MailService
 
 class AdminController(
@@ -114,16 +116,12 @@ class AdminController(
 
   val newList: Seq[(String, EmailAddress => Email)] = List(
     ResetPassword,
-    UpdateEmailAddress
+    UpdateEmailAddress,
+    AdminAccessLink,
+    AdminProbeTriggered
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
-    // ======= Admin =======
-    "admin.access_link" -> (recipient => AdminAccessLink(recipient, dummyURL)),
-    "admin.probe_triggered" -> (recipient =>
-      AdminProbeTriggered(Seq(recipient), "Taux de schtroumpfs pas assez schtroumpfés", 0.2, "bas")
-    ),
-
     // ======= DGCCRF =======
     "dgccrf.access_link" ->
       (DgccrfAgentAccessLink("DGCCRF")(_, frontRoute.dashboard.Agent.register(token = "abc"))),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -30,6 +30,7 @@ import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
 import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
+import services.emails.EmailDefinitionsConsumer.ConsumerReportReadByProNotification
 import services.emails.EmailDefinitionsDggcrf._
 import services.emails.EmailDefinitionsPro._
 import services.emails.EmailDefinitionsVarious.ResetPassword
@@ -138,21 +139,13 @@ class AdminController(
     ProReportsUnreadReminder,
     ProReportAssignedNotification,
     ConsumerReportDeletionConfirmation,
-    ConsumerReportAcknowledgment
+    ConsumerReportAcknowledgment,
+    ConsumerReportReadByProNotification
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
-    // ======= PRO =======
-
     // ======= CONSO =======
 
-    "consumer.report_transmitted" -> (recipient =>
-      ConsumerReportReadByProNotification(
-        genReport.copy(email = recipient),
-        Some(genCompany),
-        controllerComponents.messagesApi
-      )
-    ),
     "consumer.report_ack_pro_consumer" -> (recipient =>
       ConsumerProResponseNotification(
         genReport.copy(email = recipient),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -28,11 +28,8 @@ import services.PDFService
 import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
-import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
-import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
-import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
-import services.emails.EmailDefinitionsDggcrf.DgccrfReportNotification
-import services.emails.EmailDefinitionsDggcrf.DgccrfValidateEmail
+import services.emails.EmailDefinitionsDggcrf._
+import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.EmailsExamplesUtils._
@@ -127,14 +124,14 @@ class AdminController(
     DgccrfInactiveAccount,
     DgccrfDangerousProductReportNotification,
     DgccrfReportNotification,
-    DgccrfValidateEmail
+    DgccrfValidateEmail,
+    ProCompanyAccessInvitation
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= DGCCRF =======
 
     // ======= PRO =======
-    "pro.access_invitation" -> (recipient => ProCompanyAccessInvitation(recipient, genCompany, dummyURL, None)),
     "pro.access_invitation_multiple_companies" -> (recipient =>
       ProCompaniesAccessesInvitations(recipient, genCompanyList, genSiren, dummyURL)
     ),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -46,6 +46,7 @@ import services.emails.Email
 import services.emails.EmailDefinition
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
+import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
 import services.emails.MailService
 
 class AdminController(
@@ -118,13 +119,12 @@ class AdminController(
     ResetPassword,
     UpdateEmailAddress,
     AdminAccessLink,
-    AdminProbeTriggered
+    AdminProbeTriggered,
+    DgccrfAgentAccessLink
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= DGCCRF =======
-    "dgccrf.access_link" ->
-      (DgccrfAgentAccessLink("DGCCRF")(_, frontRoute.dashboard.Agent.register(token = "abc"))),
     "dgccrf.inactive_account_reminder" -> (recipient =>
       DgccrfInactiveAccount(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
     ),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -31,6 +31,7 @@ import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
 import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
 import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
+import services.emails.EmailDefinitionsDggcrf.DgccrfReportNotification
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.EmailsExamplesUtils._
@@ -42,7 +43,6 @@ import utils.Constants.ActionEvent
 import utils.Constants.EventType
 import utils._
 
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.Period
 import java.util.Locale
@@ -124,23 +124,13 @@ class AdminController(
     AdminProbeTriggered,
     DgccrfAgentAccessLink,
     DgccrfInactiveAccount,
-    DgccrfDangerousProductReportNotification
+    DgccrfDangerousProductReportNotification,
+    DgccrfReportNotification
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= DGCCRF =======
 
-    "dgccrf.report_notif_dgccrf" -> (recipient =>
-      DgccrfReportNotification(
-        List(recipient),
-        genSubscription,
-        List(
-          (genReport, List(genReportFile)),
-          (genReport.copy(tags = List(ReportTag.ReponseConso)), List(genReportFile))
-        ),
-        LocalDate.now().minusDays(10)
-      )
-    ),
     "dgccrf.validate_email" ->
       (DgccrfValidateEmail(_, 7, frontRoute.dashboard.validateEmail(""))),
 

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -202,7 +202,7 @@ class AdminController(
       }.sequence
       _ <- reportAndEmailList.map {
         case (report, Some(adminsEmails)) =>
-          mailService.send(ProNewReportNotification.build(adminsEmails, report))
+          mailService.send(ProNewReportNotification.EmailImpl(adminsEmails, report))
         case (report, None) =>
           logger.debug(s"Not sending email for report ${report.id}, no admin found")
           Future.unit

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -24,10 +24,19 @@ import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
+import services.PDFService
 import services.emails.Email._
+import services.emails.EmailDefinitionsAdmin.AdminAccessLink
+import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
+import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
+import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
+import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
-import services.PDFService
+import services.emails.EmailsExamplesUtils._
+import services.emails.Email
+import services.emails.EmailDefinition
+import services.emails.MailService
 import utils.Constants.ActionEvent.REPORT_PRO_RESPONSE
 import utils.Constants.ActionEvent
 import utils.Constants.EventType
@@ -41,14 +50,6 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import services.emails.EmailsExamplesUtils._
-import services.emails.Email
-import services.emails.EmailDefinition
-import services.emails.MailService
-import services.emails.EmailDefinitionsAdmin.AdminAccessLink
-import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
-import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
-import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
 
 class AdminController(
     reportRepository: ReportRepositoryInterface,
@@ -122,15 +123,13 @@ class AdminController(
     AdminAccessLink,
     AdminProbeTriggered,
     DgccrfAgentAccessLink,
-    DgccrfInactiveAccount
+    DgccrfInactiveAccount,
+    DgccrfDangerousProductReportNotification
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= DGCCRF =======
 
-    "dgccrf.report_dangerous_product_notification" -> (recipient =>
-      DgccrfDangerousProductReportNotification(Seq(recipient), genReport)
-    ),
     "dgccrf.report_notif_dgccrf" -> (recipient =>
       DgccrfReportNotification(
         List(recipient),
@@ -584,7 +583,7 @@ class AdminController(
       } else Future(Seq())
     _ <-
       if (ddEmails.nonEmpty) {
-        mailService.send(DgccrfDangerousProductReportNotification(ddEmails, report))
+        mailService.send(DgccrfDangerousProductReportNotification.build(ddEmails, report))
       } else {
         Future.unit
       }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -44,10 +44,11 @@ import scala.concurrent.duration._
 import services.emails.EmailsExamplesUtils._
 import services.emails.Email
 import services.emails.EmailDefinition
+import services.emails.MailService
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
-import services.emails.MailService
+import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
 
 class AdminController(
     reportRepository: ReportRepositoryInterface,
@@ -120,14 +121,13 @@ class AdminController(
     UpdateEmailAddress,
     AdminAccessLink,
     AdminProbeTriggered,
-    DgccrfAgentAccessLink
+    DgccrfAgentAccessLink,
+    DgccrfInactiveAccount
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= DGCCRF =======
-    "dgccrf.inactive_account_reminder" -> (recipient =>
-      DgccrfInactiveAccount(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
-    ),
+
     "dgccrf.report_dangerous_product_notification" -> (recipient =>
       DgccrfDangerousProductReportNotification(Seq(recipient), genReport)
     ),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -28,6 +28,7 @@ import services.PDFService
 import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
+import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotification
 import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
 import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
 import services.emails.EmailDefinitionsConsumer.ConsumerReportReadByProNotification
@@ -140,20 +141,13 @@ class AdminController(
     ProReportAssignedNotification,
     ConsumerReportDeletionConfirmation,
     ConsumerReportAcknowledgment,
-    ConsumerReportReadByProNotification
+    ConsumerReportReadByProNotification,
+    ConsumerProResponseNotification
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= CONSO =======
 
-    "consumer.report_ack_pro_consumer" -> (recipient =>
-      ConsumerProResponseNotification(
-        genReport.copy(email = recipient),
-        genReportResponse,
-        Some(genCompany),
-        controllerComponents.messagesApi
-      )
-    ),
     "consumer.report_ack_pro_consumer_on_admin_completion" -> (recipient =>
       ConsumerProResponseNotificationOnAdminCompletion(
         genReport.copy(email = recipient),
@@ -256,7 +250,7 @@ class AdminController(
       _ <- filteredEvents.map { case (report, responseEvent) =>
         val maybeCompany = report.companyId.flatMap(companyId => companies.find(_.id == companyId))
         mailService.send(
-          ConsumerProResponseNotification(
+          ConsumerProResponseNotification.EmailImpl(
             report,
             responseEvent.details.as[ReportResponse],
             maybeCompany,

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -7,7 +7,6 @@ import cats.implicits.toTraverseOps
 import config.EmailConfiguration
 import models._
 import models.admin.ReportInputList
-import models.company.Address
 import models.event.Event
 import models.report._
 import orchestrators.ReportFileOrchestrator
@@ -29,6 +28,8 @@ import services.PDFService
 import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
+import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
+import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
 import services.emails.EmailDefinitionsDggcrf._
 import services.emails.EmailDefinitionsPro._
 import services.emails.EmailDefinitionsVarious.ResetPassword
@@ -36,7 +37,6 @@ import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.EmailsExamplesUtils._
 import services.emails.Email
 import services.emails.EmailDefinition
-import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
 import services.emails.MailService
 import utils.Constants.ActionEvent.REPORT_PRO_RESPONSE
 import utils.Constants.ActionEvent
@@ -137,184 +137,15 @@ class AdminController(
     ProReportsReadReminder,
     ProReportsUnreadReminder,
     ProReportAssignedNotification,
-    ConsumerReportDeletionConfirmation
+    ConsumerReportDeletionConfirmation,
+    ConsumerReportAcknowledgment
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
     // ======= CONSO =======
-    "consumer.report_ack" -> (recipient =>
-      ConsumerReportAcknowledgment(
-        genReport.copy(email = recipient),
-        Some(genCompany),
-        genEvent,
-        Nil,
-        controllerComponents.messagesApi
-      )
-    ),
-    "consumer.report_ack_case_reponseconso" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(status = ReportStatus.NA, tags = List(ReportTag.ReponseConso), email = recipient),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_dispute" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(tags = List(ReportTag.LitigeContractuel), email = recipient),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_dangerous_product" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.TraitementEnCours,
-            tags = List(ReportTag.ProduitDangereux),
-            email = recipient
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_euro" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.NA,
-            companyAddress = Address(country = Some(Country.Italie)),
-            email = recipient
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_euro_and_dispute" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.NA,
-            tags = List(ReportTag.LitigeContractuel),
-            companyAddress = Address(country = Some(Country.Islande)),
-            email = recipient
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_andorre" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.NA,
-            companyAddress = Address(country = Some(Country.Andorre)),
-            email = recipient
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_andorre_and_dispute" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.NA,
-            tags = List(ReportTag.LitigeContractuel),
-            companyAddress = Address(country = Some(Country.Andorre)),
-            email = recipient
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_suisse" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.NA,
-            companyAddress = Address(country = Some(Country.Suisse)),
-            email = recipient
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_suisse_and_dispute" -> (recipient =>
-      ConsumerReportAcknowledgment(
-        genReport.copy(
-          status = ReportStatus.NA,
-          tags = List(ReportTag.LitigeContractuel),
-          companyAddress = Address(country = Some(Country.Suisse)),
-          email = recipient
-        ),
-        Some(genCompany),
-        genEvent,
-        Nil,
-        controllerComponents.messagesApi
-      )
-    ),
-    "consumer.report_ack_case_compagnie_aerienne" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.NA,
-            email = recipient,
-            tags = List(ReportTag.CompagnieAerienne)
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_abroad_default" ->
-      (recipient =>
-        ConsumerReportAcknowledgment(
-          genReport.copy(
-            status = ReportStatus.NA,
-            companyAddress = Address(country = Some(Country.Bahamas)),
-            email = recipient
-          ),
-          Some(genCompany),
-          genEvent,
-          Nil,
-          controllerComponents.messagesApi
-        )
-      ),
-    "consumer.report_ack_case_abroad_default_and_dispute" -> (recipient =>
-      ConsumerReportAcknowledgment(
-        genReport.copy(
-          status = ReportStatus.NA,
-          tags = List(ReportTag.LitigeContractuel),
-          companyAddress = Address(country = Some(Country.Bahamas)),
-          email = recipient
-        ),
-        Some(genCompany),
-        genEvent,
-        Nil,
-        controllerComponents.messagesApi
-      )
-    ),
+
     "consumer.report_transmitted" -> (recipient =>
       ConsumerReportReadByProNotification(
         genReport.copy(email = recipient),
@@ -496,7 +327,7 @@ class AdminController(
         event match {
           case Some(evt) =>
             Some(
-              ConsumerReportAcknowledgment(
+              ConsumerReportAcknowledgment.EmailImpl(
                 report,
                 maybeCompany,
                 evt,

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -28,11 +28,7 @@ import services.PDFService
 import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
-import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotification
-import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotificationOnAdminCompletion
-import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
-import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
-import services.emails.EmailDefinitionsConsumer.ConsumerReportReadByProNotification
+import services.emails.EmailDefinitionsConsumer._
 import services.emails.EmailDefinitionsDggcrf._
 import services.emails.EmailDefinitionsPro._
 import services.emails.EmailDefinitionsVarious.ResetPassword
@@ -144,27 +140,13 @@ class AdminController(
     ConsumerReportAcknowledgment,
     ConsumerReportReadByProNotification,
     ConsumerProResponseNotification,
-    ConsumerProResponseNotificationOnAdminCompletion
+    ConsumerProResponseNotificationOnAdminCompletion,
+    ConsumerReportClosedNoReading
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= CONSO =======
 
-    "consumer.report_closed_no_reading" -> (recipient =>
-      ConsumerReportClosedNoReading(
-        genReport.copy(email = recipient),
-        Some(genCompany),
-        controllerComponents.messagesApi
-      )
-    ),
-    "consumer.report_closed_no_reading_case_dispute" ->
-      (recipient =>
-        ConsumerReportClosedNoReading(
-          genReport.copy(email = recipient, tags = List(ReportTag.LitigeContractuel)),
-          Some(genCompany),
-          controllerComponents.messagesApi
-        )
-      ),
     "consumer.report_closed_no_action" -> (recipient =>
       ConsumerReportClosedNoAction(
         genReport.copy(email = recipient),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -29,11 +29,7 @@ import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsDggcrf._
-import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
-import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
-import services.emails.EmailDefinitionsPro.ProNewCompaniesAccesses
-import services.emails.EmailDefinitionsPro.ProNewCompanyAccess
-import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
+import services.emails.EmailDefinitionsPro._
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.EmailsExamplesUtils._
@@ -133,15 +129,13 @@ class AdminController(
     ProCompaniesAccessesInvitations,
     ProNewCompanyAccess,
     ProNewCompaniesAccesses,
-    ProResponseAcknowledgment
+    ProResponseAcknowledgment,
+    ProResponseAcknowledgmentOnAdminCompletion
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
-    "pro.report_ack_pro_on_admin_completion" -> (recipient =>
-      ProResponseAcknowledgmentOnAdminCompletion(genReport, List(genUser.copy(email = recipient), genUser, genUser))
-    ),
     "pro.report_notification" -> (recipient => ProNewReportNotification(NonEmptyList.of(recipient), genReport)),
     "pro.report_reopening_notification" -> (recipient => ProReportReOpeningNotification(List(recipient), genReport)),
     "pro.reports_transmitted_reminder" -> (recipient => {

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -26,6 +26,7 @@ import repositories.report.ReportRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
 import services.Email._
 import services.EmailDefinitions.ResetPassword
+import services.EmailDefinitions.UpdateEmailAddress
 import services.Email
 import services.EmailDefinition
 import services.MailService
@@ -112,13 +113,11 @@ class AdminController(
   )
 
   val newList: Seq[(String, EmailAddress => Email)] = List(
-    ResetPassword
+    ResetPassword,
+    UpdateEmailAddress
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
-    // ======= Divers =======
-    "various.update_email_address" -> (recipient => UpdateEmailAddress(recipient, dummyURL, daysBeforeExpiry = 2)),
-
     // ======= Admin =======
     "admin.access_link" -> (recipient => AdminAccessLink(recipient, dummyURL)),
     "admin.probe_triggered" -> (recipient =>

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -32,6 +32,7 @@ import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
 import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
 import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
 import services.emails.EmailDefinitionsDggcrf.DgccrfReportNotification
+import services.emails.EmailDefinitionsDggcrf.DgccrfValidateEmail
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.EmailsExamplesUtils._
@@ -125,14 +126,12 @@ class AdminController(
     DgccrfAgentAccessLink,
     DgccrfInactiveAccount,
     DgccrfDangerousProductReportNotification,
-    DgccrfReportNotification
+    DgccrfReportNotification,
+    DgccrfValidateEmail
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= DGCCRF =======
-
-    "dgccrf.validate_email" ->
-      (DgccrfValidateEmail(_, 7, frontRoute.dashboard.validateEmail(""))),
 
     // ======= PRO =======
     "pro.access_invitation" -> (recipient => ProCompanyAccessInvitation(recipient, genCompany, dummyURL, None)),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -133,19 +133,13 @@ class AdminController(
     ProNewReportNotification,
     ProReportReOpeningNotification,
     ProReportsReadReminder,
-    ProReportsUnreadReminder
+    ProReportsUnreadReminder,
+    ProReportAssignedNotification
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
-    "pro.report_assignement_to_other" -> (recipient =>
-      ProReportAssignedNotification(
-        report = genReport,
-        assigningUser = genUser,
-        assignedUser = genUser.copy(email = recipient)
-      )
-    ),
     "pro.report_deletion_confirmation" -> (_ =>
       ReportDeletionConfirmation(
         genReport,

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -24,12 +24,9 @@ import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
-import services.Email._
-import services.EmailDefinitions.ResetPassword
-import services.EmailDefinitions.UpdateEmailAddress
-import services.Email
-import services.EmailDefinition
-import services.MailService
+import services.emails.Email._
+import services.emails.EmailDefinitions.ResetPassword
+import services.emails.EmailDefinitions.UpdateEmailAddress
 import services.PDFService
 import utils.Constants.ActionEvent.REPORT_PRO_RESPONSE
 import utils.Constants.ActionEvent
@@ -44,7 +41,10 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import services.EmailsExamplesUtils._
+import services.emails.EmailsExamplesUtils._
+import services.emails.Email
+import services.emails.EmailDefinition
+import services.emails.MailService
 
 class AdminController(
     reportRepository: ReportRepositoryInterface,

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -269,7 +269,7 @@ class AdminController(
       } else Future(Seq())
     _ <-
       if (ddEmails.nonEmpty) {
-        mailService.send(DgccrfDangerousProductReportNotification.build(ddEmails, report))
+        mailService.send(DgccrfDangerousProductReportNotification.EmailImpl(ddEmails, report))
       } else {
         Future.unit
       }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -25,8 +25,8 @@ import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
 import services.emails.Email._
-import services.emails.EmailDefinitions.ResetPassword
-import services.emails.EmailDefinitions.UpdateEmailAddress
+import services.emails.EmailDefinitionsVarious.ResetPassword
+import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.PDFService
 import utils.Constants.ActionEvent.REPORT_PRO_RESPONSE
 import utils.Constants.ActionEvent

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -31,6 +31,7 @@ import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsDggcrf._
 import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
 import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
+import services.emails.EmailDefinitionsPro.ProNewCompaniesAccesses
 import services.emails.EmailDefinitionsPro.ProNewCompanyAccess
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
@@ -129,15 +130,13 @@ class AdminController(
     DgccrfValidateEmail,
     ProCompanyAccessInvitation,
     ProCompaniesAccessesInvitations,
-    ProNewCompanyAccess
+    ProNewCompanyAccess,
+    ProNewCompaniesAccesses
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
-    // ======= DGCCRF =======
-
     // ======= PRO =======
 
-    "pro.new_companies_accesses" -> (recipient => ProNewCompaniesAccesses(recipient, genCompanyList, genSiren)),
     "pro.report_ack_pro" -> (recipient =>
       ProResponseAcknowledgment(genReport, genReportResponse, genUser.copy(email = recipient))
     ),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -25,7 +25,6 @@ import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
 import services.PDFService
-import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsConsumer._
@@ -142,16 +141,11 @@ class AdminController(
     ConsumerProResponseNotification,
     ConsumerProResponseNotificationOnAdminCompletion,
     ConsumerReportClosedNoReading,
-    ConsumerReportClosedNoAction
+    ConsumerReportClosedNoAction,
+    ConsumerValidateEmail
   ).flatMap(readExamplesWithFullKey)
 
-  val availableEmails = List[(String, EmailAddress => Email)](
-    // ======= CONSO =======
-
-    "consumer.validate_email" -> (recipient =>
-      ConsumerValidateEmail(EmailValidation(email = recipient), None, controllerComponents.messagesApi)
-    )
-  )
+  val availableEmails = List[(String, EmailAddress => Email)]()
 
   def getEmailCodes = SecuredAction.andThen(WithRole(UserRole.Admin)).async { _ =>
     val codesFromNewList = newList.map(_._1)

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -130,13 +130,13 @@ class AdminController(
     ProNewCompanyAccess,
     ProNewCompaniesAccesses,
     ProResponseAcknowledgment,
-    ProResponseAcknowledgmentOnAdminCompletion
+    ProResponseAcknowledgmentOnAdminCompletion,
+    ProNewReportNotification
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
-    "pro.report_notification" -> (recipient => ProNewReportNotification(NonEmptyList.of(recipient), genReport)),
     "pro.report_reopening_notification" -> (recipient => ProReportReOpeningNotification(List(recipient), genReport)),
     "pro.reports_transmitted_reminder" -> (recipient => {
       val report1 = genReport
@@ -495,7 +495,7 @@ class AdminController(
       }.sequence
       _ <- reportAndEmailList.map {
         case (report, Some(adminsEmails)) =>
-          mailService.send(ProNewReportNotification(adminsEmails, report))
+          mailService.send(ProNewReportNotification.build(adminsEmails, report))
         case (report, None) =>
           logger.debug(s"Not sending email for report ${report.id}, no admin found")
           Future.unit

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -31,6 +31,7 @@ import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsDggcrf._
 import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
 import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
+import services.emails.EmailDefinitionsPro.ProNewCompanyAccess
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.EmailsExamplesUtils._
@@ -127,7 +128,8 @@ class AdminController(
     DgccrfReportNotification,
     DgccrfValidateEmail,
     ProCompanyAccessInvitation,
-    ProCompaniesAccessesInvitations
+    ProCompaniesAccessesInvitations,
+    ProNewCompanyAccess
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
@@ -135,7 +137,6 @@ class AdminController(
 
     // ======= PRO =======
 
-    "pro.new_company_access"     -> (recipient => ProNewCompanyAccess(recipient, genCompany, None)),
     "pro.new_companies_accesses" -> (recipient => ProNewCompaniesAccesses(recipient, genCompanyList, genSiren)),
     "pro.report_ack_pro" -> (recipient =>
       ProResponseAcknowledgment(genReport, genReportResponse, genUser.copy(email = recipient))

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -29,6 +29,7 @@ import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsDggcrf._
+import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
 import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
@@ -125,16 +126,15 @@ class AdminController(
     DgccrfDangerousProductReportNotification,
     DgccrfReportNotification,
     DgccrfValidateEmail,
-    ProCompanyAccessInvitation
+    ProCompanyAccessInvitation,
+    ProCompaniesAccessesInvitations
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= DGCCRF =======
 
     // ======= PRO =======
-    "pro.access_invitation_multiple_companies" -> (recipient =>
-      ProCompaniesAccessesInvitations(recipient, genCompanyList, genSiren, dummyURL)
-    ),
+
     "pro.new_company_access"     -> (recipient => ProNewCompanyAccess(recipient, genCompany, None)),
     "pro.new_companies_accesses" -> (recipient => ProNewCompaniesAccesses(recipient, genCompanyList, genSiren)),
     "pro.report_ack_pro" -> (recipient =>

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -141,26 +141,13 @@ class AdminController(
     ConsumerReportReadByProNotification,
     ConsumerProResponseNotification,
     ConsumerProResponseNotificationOnAdminCompletion,
-    ConsumerReportClosedNoReading
+    ConsumerReportClosedNoReading,
+    ConsumerReportClosedNoAction
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= CONSO =======
 
-    "consumer.report_closed_no_action" -> (recipient =>
-      ConsumerReportClosedNoAction(
-        genReport.copy(email = recipient),
-        Some(genCompany),
-        controllerComponents.messagesApi
-      )
-    ),
-    "consumer.report_closed_no_action_case_dispute" -> (recipient =>
-      ConsumerReportClosedNoAction(
-        genReport.copy(email = recipient, tags = List(ReportTag.LitigeContractuel)),
-        Some(genCompany),
-        controllerComponents.messagesApi
-      )
-    ),
     "consumer.validate_email" -> (recipient =>
       ConsumerValidateEmail(EmailValidation(email = recipient), None, controllerComponents.messagesApi)
     )

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -33,6 +33,7 @@ import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
 import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
 import services.emails.EmailDefinitionsPro.ProNewCompaniesAccesses
 import services.emails.EmailDefinitionsPro.ProNewCompanyAccess
+import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
 import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.EmailsExamplesUtils._
@@ -131,15 +132,13 @@ class AdminController(
     ProCompanyAccessInvitation,
     ProCompaniesAccessesInvitations,
     ProNewCompanyAccess,
-    ProNewCompaniesAccesses
+    ProNewCompaniesAccesses,
+    ProResponseAcknowledgment
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= PRO =======
 
-    "pro.report_ack_pro" -> (recipient =>
-      ProResponseAcknowledgment(genReport, genReportResponse, genUser.copy(email = recipient))
-    ),
     "pro.report_ack_pro_on_admin_completion" -> (recipient =>
       ProResponseAcknowledgmentOnAdminCompletion(genReport, List(genUser.copy(email = recipient), genUser, genUser))
     ),

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -29,6 +29,7 @@ import services.emails.Email._
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotification
+import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotificationOnAdminCompletion
 import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
 import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
 import services.emails.EmailDefinitionsConsumer.ConsumerReportReadByProNotification
@@ -142,19 +143,13 @@ class AdminController(
     ConsumerReportDeletionConfirmation,
     ConsumerReportAcknowledgment,
     ConsumerReportReadByProNotification,
-    ConsumerProResponseNotification
+    ConsumerProResponseNotification,
+    ConsumerProResponseNotificationOnAdminCompletion
   ).flatMap(readExamplesWithFullKey)
 
   val availableEmails = List[(String, EmailAddress => Email)](
     // ======= CONSO =======
 
-    "consumer.report_ack_pro_consumer_on_admin_completion" -> (recipient =>
-      ConsumerProResponseNotificationOnAdminCompletion(
-        genReport.copy(email = recipient),
-        Some(genCompany),
-        controllerComponents.messagesApi
-      )
-    ),
     "consumer.report_closed_no_reading" -> (recipient =>
       ConsumerReportClosedNoReading(
         genReport.copy(email = recipient),

--- a/app/loader/SignalConsoApplicationLoader.scala
+++ b/app/loader/SignalConsoApplicationLoader.scala
@@ -88,6 +88,8 @@ import repositories.usersettings.UserReportsFiltersRepositoryInterface
 import repositories.website.WebsiteRepository
 import repositories.website.WebsiteRepositoryInterface
 import services._
+import services.emails.MailRetriesService
+import services.emails.MailService
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import tasks.account.InactiveAccountTask

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -20,9 +20,9 @@ import play.api.Logger
 import repositories.accesstoken.AccessTokenRepositoryInterface
 import services.Email.AdminAccessLink
 import services.Email.DgccrfAgentAccessLink
-import services.Email.UpdateEmailAddress
 import services.Email
 import services.EmailAddressService
+import services.EmailDefinitions.UpdateEmailAddress
 import services.MailServiceInterface
 import utils.EmailAddress
 import utils.FrontRoute
@@ -128,7 +128,7 @@ class AccessesOrchestrator(
             )
         }
       _ <- mailService.send(
-        UpdateEmailAddress(
+        UpdateEmailAddress.build(
           newEmail,
           frontRoute.dashboard.updateEmail(token.token),
           tokenConfiguration.updateEmailAddressDuration.getDays

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -247,14 +247,14 @@ class AccessesOrchestrator(
         (
           EmailAddressService.isEmailAcceptableForDgccrfAccount _,
           tokenConfiguration.dgccrfJoinDuration,
-          DgccrfAgentAccessLink.build("DGCCRF") _,
+          DgccrfAgentAccessLink.EmailImpl("DGCCRF") _,
           frontRoute.dashboard.Agent.register _
         )
       case DGALAccount =>
         (
           EmailAddressService.isEmailAcceptableForDgalAccount _,
           tokenConfiguration.dgccrfJoinDuration,
-          DgccrfAgentAccessLink.build("DGAL") _,
+          DgccrfAgentAccessLink.EmailImpl("DGAL") _,
           frontRoute.dashboard.Agent.register _
         )
       case AdminAccount =>

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -128,7 +128,7 @@ class AccessesOrchestrator(
             )
         }
       _ <- mailService.send(
-        UpdateEmailAddress.EmailImpl(
+        UpdateEmailAddress.Email(
           newEmail,
           frontRoute.dashboard.updateEmail(token.token),
           tokenConfiguration.updateEmailAddressDuration.getDays
@@ -247,21 +247,21 @@ class AccessesOrchestrator(
         (
           EmailAddressService.isEmailAcceptableForDgccrfAccount _,
           tokenConfiguration.dgccrfJoinDuration,
-          DgccrfAgentAccessLink.EmailImpl("DGCCRF") _,
+          DgccrfAgentAccessLink.Email("DGCCRF") _,
           frontRoute.dashboard.Agent.register _
         )
       case DGALAccount =>
         (
           EmailAddressService.isEmailAcceptableForDgalAccount _,
           tokenConfiguration.dgccrfJoinDuration,
-          DgccrfAgentAccessLink.EmailImpl("DGAL") _,
+          DgccrfAgentAccessLink.Email("DGAL") _,
           frontRoute.dashboard.Agent.register _
         )
       case AdminAccount =>
         (
           EmailAddressService.isEmailAcceptableForAdminAccount _,
           tokenConfiguration.adminJoinDuration.toJava,
-          AdminAccessLink.EmailImpl,
+          AdminAccessLink.Email,
           frontRoute.dashboard.Admin.register _
         )
     }
@@ -319,7 +319,7 @@ class AccessesOrchestrator(
         )
       )
       _ <- mailService.send(
-        DgccrfValidateEmail.EmailImpl(
+        DgccrfValidateEmail.Email(
           user.email,
           tokenConfiguration.dgccrfRevalidationTokenDuration.map(_.getDays).getOrElse(7),
           frontRoute.dashboard.validateEmail(token.token)

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -18,12 +18,12 @@ import models.token.TokenKind.DGCCRFAccount
 import models.token.TokenKind.ValidateEmail
 import play.api.Logger
 import repositories.accesstoken.AccessTokenRepositoryInterface
-import services.Email.AdminAccessLink
-import services.Email.DgccrfAgentAccessLink
-import services.Email
+import services.emails.Email.AdminAccessLink
+import services.emails.Email.DgccrfAgentAccessLink
 import services.EmailAddressService
-import services.EmailDefinitions.UpdateEmailAddress
-import services.MailServiceInterface
+import services.emails.EmailDefinitions.UpdateEmailAddress
+import services.emails.Email
+import services.emails.MailServiceInterface
 import utils.EmailAddress
 import utils.FrontRoute
 import utils.PasswordComplexityHelper

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -21,7 +21,7 @@ import repositories.accesstoken.AccessTokenRepositoryInterface
 import services.emails.Email.AdminAccessLink
 import services.emails.Email.DgccrfAgentAccessLink
 import services.EmailAddressService
-import services.emails.EmailDefinitions.UpdateEmailAddress
+import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.Email
 import services.emails.MailServiceInterface
 import utils.EmailAddress

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -20,9 +20,9 @@ import play.api.Logger
 import repositories.accesstoken.AccessTokenRepositoryInterface
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
+import services.emails.EmailDefinitionsDggcrf.DgccrfValidateEmail
 import services.EmailAddressService
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
-import services.emails.Email
 import services.emails.MailServiceInterface
 import utils.EmailAddress
 import utils.FrontRoute
@@ -319,7 +319,7 @@ class AccessesOrchestrator(
         )
       )
       _ <- mailService.send(
-        Email.DgccrfValidateEmail(
+        DgccrfValidateEmail.build(
           user.email,
           tokenConfiguration.dgccrfRevalidationTokenDuration.map(_.getDays).getOrElse(7),
           frontRoute.dashboard.validateEmail(token.token)

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -12,16 +12,16 @@ import models.token.AgentAccessToken
 import models.token.DGCCRFUserActivationToken
 import models.token.TokenKind
 import models.token.TokenKind.AdminAccount
-import models.token.TokenKind.UpdateEmail
 import models.token.TokenKind.DGALAccount
 import models.token.TokenKind.DGCCRFAccount
+import models.token.TokenKind.UpdateEmail
 import models.token.TokenKind.ValidateEmail
 import play.api.Logger
 import repositories.accesstoken.AccessTokenRepositoryInterface
+import services.EmailAddressService
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
 import services.emails.EmailDefinitionsDggcrf.DgccrfValidateEmail
-import services.EmailAddressService
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.MailServiceInterface
 import utils.EmailAddress
@@ -128,7 +128,7 @@ class AccessesOrchestrator(
             )
         }
       _ <- mailService.send(
-        UpdateEmailAddress.build(
+        UpdateEmailAddress.EmailImpl(
           newEmail,
           frontRoute.dashboard.updateEmail(token.token),
           tokenConfiguration.updateEmailAddressDuration.getDays
@@ -261,7 +261,7 @@ class AccessesOrchestrator(
         (
           EmailAddressService.isEmailAcceptableForAdminAccount _,
           tokenConfiguration.adminJoinDuration.toJava,
-          AdminAccessLink.build _,
+          AdminAccessLink.EmailImpl,
           frontRoute.dashboard.Admin.register _
         )
     }

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -319,7 +319,7 @@ class AccessesOrchestrator(
         )
       )
       _ <- mailService.send(
-        DgccrfValidateEmail.build(
+        DgccrfValidateEmail.EmailImpl(
           user.email,
           tokenConfiguration.dgccrfRevalidationTokenDuration.map(_.getDays).getOrElse(7),
           frontRoute.dashboard.validateEmail(token.token)

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -19,7 +19,7 @@ import models.token.TokenKind.ValidateEmail
 import play.api.Logger
 import repositories.accesstoken.AccessTokenRepositoryInterface
 import services.emails.EmailDefinitionsAdmin.AdminAccessLink
-import services.emails.Email.DgccrfAgentAccessLink
+import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
 import services.EmailAddressService
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import services.emails.Email
@@ -247,14 +247,14 @@ class AccessesOrchestrator(
         (
           EmailAddressService.isEmailAcceptableForDgccrfAccount _,
           tokenConfiguration.dgccrfJoinDuration,
-          DgccrfAgentAccessLink("DGCCRF") _,
+          DgccrfAgentAccessLink.build("DGCCRF") _,
           frontRoute.dashboard.Agent.register _
         )
       case DGALAccount =>
         (
           EmailAddressService.isEmailAcceptableForDgalAccount _,
           tokenConfiguration.dgccrfJoinDuration,
-          DgccrfAgentAccessLink("DGAL") _,
+          DgccrfAgentAccessLink.build("DGAL") _,
           frontRoute.dashboard.Agent.register _
         )
       case AdminAccount =>

--- a/app/orchestrators/AccessesOrchestrator.scala
+++ b/app/orchestrators/AccessesOrchestrator.scala
@@ -18,7 +18,7 @@ import models.token.TokenKind.DGCCRFAccount
 import models.token.TokenKind.ValidateEmail
 import play.api.Logger
 import repositories.accesstoken.AccessTokenRepositoryInterface
-import services.emails.Email.AdminAccessLink
+import services.emails.EmailDefinitionsAdmin.AdminAccessLink
 import services.emails.Email.DgccrfAgentAccessLink
 import services.EmailAddressService
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
@@ -261,7 +261,7 @@ class AccessesOrchestrator(
         (
           EmailAddressService.isEmailAcceptableForAdminAccount _,
           tokenConfiguration.adminJoinDuration.toJava,
-          AdminAccessLink,
+          AdminAccessLink.build _,
           frontRoute.dashboard.Admin.register _
         )
     }

--- a/app/orchestrators/AuthOrchestrator.scala
+++ b/app/orchestrators/AuthOrchestrator.scala
@@ -21,8 +21,8 @@ import play.api.mvc.Request
 import repositories.authattempt.AuthAttemptRepositoryInterface
 import repositories.authtoken.AuthTokenRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.EmailDefinitions.ResetPassword
-import services.MailService
+import services.emails.EmailDefinitions.ResetPassword
+import services.emails.MailService
 import utils.Logs.RichLogger
 import utils.EmailAddress
 import utils.PasswordComplexityHelper

--- a/app/orchestrators/AuthOrchestrator.scala
+++ b/app/orchestrators/AuthOrchestrator.scala
@@ -121,7 +121,7 @@ class AuthOrchestrator(
           _ = logger.debug(s"Creating auth token for ${user.id}")
           authToken <- authTokenRepository.create(AuthToken(UUID.randomUUID(), user.id, authTokenExpiration))
           _ = logger.debug(s"Sending reset email to ${user.id}")
-          _ <- mailService.send(ResetPassword.EmailImpl(user, authToken))
+          _ <- mailService.send(ResetPassword.Email(user, authToken))
         } yield ()
       case _ =>
         logger.warnWithTitle("reset_pwd_user_not_found", "User not found, cannot reset password")

--- a/app/orchestrators/AuthOrchestrator.scala
+++ b/app/orchestrators/AuthOrchestrator.scala
@@ -21,7 +21,7 @@ import play.api.mvc.Request
 import repositories.authattempt.AuthAttemptRepositoryInterface
 import repositories.authtoken.AuthTokenRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.EmailDefinitions.ResetPassword
+import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.MailService
 import utils.Logs.RichLogger
 import utils.EmailAddress

--- a/app/orchestrators/AuthOrchestrator.scala
+++ b/app/orchestrators/AuthOrchestrator.scala
@@ -121,7 +121,7 @@ class AuthOrchestrator(
           _ = logger.debug(s"Creating auth token for ${user.id}")
           authToken <- authTokenRepository.create(AuthToken(UUID.randomUUID(), user.id, authTokenExpiration))
           _ = logger.debug(s"Sending reset email to ${user.id}")
-          _ <- mailService.send(ResetPassword.build(user, authToken))
+          _ <- mailService.send(ResetPassword.EmailImpl(user, authToken))
         } yield ()
       case _ =>
         logger.warnWithTitle("reset_pwd_user_not_found", "User not found, cannot reset password")

--- a/app/orchestrators/EmailValidationOrchestrator.scala
+++ b/app/orchestrators/EmailValidationOrchestrator.scala
@@ -89,7 +89,7 @@ class EmailValidationOrchestrator(
         if (isEmailNotValidatedOrOutdated(emailValidation.lastValidationDate)) {
           logger.debug(s"Email ${emailValidation.email} not validated our outdated, sending email")
           mailService
-            .send(ConsumerValidateEmail.EmailImpl(emailValidation, locale, messagesApi))
+            .send(ConsumerValidateEmail.Email(emailValidation, locale, messagesApi))
             .map(_ => EmailValidationResult.failure)
         } else {
           logger.debug(s"Email validated")

--- a/app/orchestrators/EmailValidationOrchestrator.scala
+++ b/app/orchestrators/EmailValidationOrchestrator.scala
@@ -5,20 +5,16 @@ import config.EmailConfiguration
 import controllers.error.AppError
 import eu.timepit.refined.api.RefType
 import models.EmailApi.EmailString
-import models.EmailValidation
 import models.EmailValidation.EmailValidationThreshold
-import models.EmailValidationApi
-import models.EmailValidationFilter
-import models.PaginatedResult
-import models.PaginatedSearch
-import utils.EmailAddress
+import models._
 import models.email.EmailValidationResult
 import models.email.ValidateEmailCode
 import play.api.Logger
 import play.api.i18n.MessagesApi
 import repositories.emailvalidation.EmailValidationRepositoryInterface
-import services.emails.Email.ConsumerValidateEmail
+import services.emails.EmailDefinitionsConsumer.ConsumerValidateEmail
 import services.emails.MailServiceInterface
+import utils.EmailAddress
 
 import java.time.OffsetDateTime
 import java.util.Locale
@@ -93,7 +89,7 @@ class EmailValidationOrchestrator(
         if (isEmailNotValidatedOrOutdated(emailValidation.lastValidationDate)) {
           logger.debug(s"Email ${emailValidation.email} not validated our outdated, sending email")
           mailService
-            .send(ConsumerValidateEmail(emailValidation, locale, messagesApi))
+            .send(ConsumerValidateEmail.EmailImpl(emailValidation, locale, messagesApi))
             .map(_ => EmailValidationResult.failure)
         } else {
           logger.debug(s"Email validated")

--- a/app/orchestrators/EmailValidationOrchestrator.scala
+++ b/app/orchestrators/EmailValidationOrchestrator.scala
@@ -11,14 +11,14 @@ import models.EmailValidationApi
 import models.EmailValidationFilter
 import models.PaginatedResult
 import models.PaginatedSearch
-import services.MailServiceInterface
 import utils.EmailAddress
 import models.email.EmailValidationResult
 import models.email.ValidateEmailCode
 import play.api.Logger
 import play.api.i18n.MessagesApi
 import repositories.emailvalidation.EmailValidationRepositoryInterface
-import services.Email.ConsumerValidateEmail
+import services.emails.Email.ConsumerValidateEmail
+import services.emails.MailServiceInterface
 
 import java.time.OffsetDateTime
 import java.util.Locale

--- a/app/orchestrators/ProAccessTokenOrchestrator.scala
+++ b/app/orchestrators/ProAccessTokenOrchestrator.scala
@@ -157,7 +157,7 @@ class ProAccessTokenOrchestrator(
   def addInvitedUserAndNotify(user: User, company: Company, level: AccessLevel, invitedBy: Option[User]): Future[Unit] =
     for {
       _ <- accessTokenRepository.giveCompanyAccess(company, user, level)
-      _ <- mailService.send(ProNewCompanyAccess.EmailImpl(user.email, company, invitedBy))
+      _ <- mailService.send(ProNewCompanyAccess.Email(user.email, company, invitedBy))
       _ = logger.debug(s"User ${user.id} may now access company ${company.id}")
     } yield ()
 
@@ -167,7 +167,7 @@ class ProAccessTokenOrchestrator(
       _ <- companies match {
         case Nil => Future.successful(())
         case c :: _ =>
-          mailService.send(ProNewCompaniesAccesses.EmailImpl(user.email, companies, SIREN.fromSIRET(c.siret)))
+          mailService.send(ProNewCompaniesAccesses.Email(user.email, companies, SIREN.fromSIRET(c.siret)))
       }
       _ = logger.debug(s"User ${user.id} may now access companies ${companies.map(_.siret)}")
     } yield ()
@@ -207,7 +207,7 @@ class ProAccessTokenOrchestrator(
     for {
       tokenCode <- genInvitationToken(company, level, tokenConfiguration.companyJoinDuration, email)
       _ <- mailService.send(
-        ProCompanyAccessInvitation.EmailImpl(
+        ProCompanyAccessInvitation.Email(
           recipient = email,
           company = company,
           invitationUrl = frontRoute.dashboard.Pro.register(company.siret, tokenCode),
@@ -234,7 +234,7 @@ class ProAccessTokenOrchestrator(
         case Nil => Future.successful(())
         case (tokenCode, c) :: _ =>
           mailService.send(
-            ProCompaniesAccessesInvitations.EmailImpl(
+            ProCompaniesAccessesInvitations.Email(
               recipient = email,
               companies = list.map(_._2),
               siren = SIREN.fromSIRET(c.siret),

--- a/app/orchestrators/ProAccessTokenOrchestrator.scala
+++ b/app/orchestrators/ProAccessTokenOrchestrator.scala
@@ -17,9 +17,9 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.Email.ProCompaniesAccessesInvitations
 import services.emails.Email.ProNewCompaniesAccesses
 import services.emails.Email.ProNewCompanyAccess
+import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
 import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
 import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent
@@ -233,7 +233,7 @@ class ProAccessTokenOrchestrator(
         case Nil => Future.successful(())
         case (tokenCode, c) :: _ =>
           mailService.send(
-            ProCompaniesAccessesInvitations(
+            ProCompaniesAccessesInvitations.build(
               recipient = email,
               companies = list.map(_._2),
               siren = SIREN.fromSIRET(c.siret),

--- a/app/orchestrators/ProAccessTokenOrchestrator.scala
+++ b/app/orchestrators/ProAccessTokenOrchestrator.scala
@@ -9,8 +9,8 @@ import models.company.AccessLevel
 import models.company.Company
 import models.event.Event
 import models.event.Event.stringToDetailsJsValue
-import models.token._
 import models.token.TokenKind.CompanyJoin
+import models.token._
 import play.api.Logger
 import repositories.accesstoken.AccessTokenRepositoryInterface
 import repositories.company.CompanyRepositoryInterface
@@ -18,17 +18,13 @@ import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
 import services.emails.Email.ProCompaniesAccessesInvitations
-import services.emails.Email.ProCompanyAccessInvitation
 import services.emails.Email.ProNewCompaniesAccesses
 import services.emails.Email.ProNewCompanyAccess
+import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
 import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent
 import utils.Constants.EventType
-import utils.EmailAddress
-import utils.FrontRoute
-import utils.PasswordComplexityHelper
-import utils.SIREN
-import utils.SIRET
+import utils._
 
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -210,7 +206,7 @@ class ProAccessTokenOrchestrator(
     for {
       tokenCode <- genInvitationToken(company, level, tokenConfiguration.companyJoinDuration, email)
       _ <- mailService.send(
-        ProCompanyAccessInvitation(
+        ProCompanyAccessInvitation.build(
           recipient = email,
           company = company,
           invitationUrl = frontRoute.dashboard.Pro.register(company.siret, tokenCode),

--- a/app/orchestrators/ProAccessTokenOrchestrator.scala
+++ b/app/orchestrators/ProAccessTokenOrchestrator.scala
@@ -17,9 +17,9 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.Email.ProNewCompaniesAccesses
 import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
 import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
+import services.emails.EmailDefinitionsPro.ProNewCompaniesAccesses
 import services.emails.EmailDefinitionsPro.ProNewCompanyAccess
 import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent
@@ -166,7 +166,7 @@ class ProAccessTokenOrchestrator(
       _ <- Future.sequence(companies.map(company => accessTokenRepository.giveCompanyAccess(company, user, level)))
       _ <- companies match {
         case Nil    => Future.successful(())
-        case c :: _ => mailService.send(ProNewCompaniesAccesses(user.email, companies, SIREN.fromSIRET(c.siret)))
+        case c :: _ => mailService.send(ProNewCompaniesAccesses.build(user.email, companies, SIREN.fromSIRET(c.siret)))
       }
       _ = logger.debug(s"User ${user.id} may now access companies ${companies.map(_.siret)}")
     } yield ()

--- a/app/orchestrators/ProAccessTokenOrchestrator.scala
+++ b/app/orchestrators/ProAccessTokenOrchestrator.scala
@@ -18,9 +18,9 @@ import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
 import services.emails.Email.ProNewCompaniesAccesses
-import services.emails.Email.ProNewCompanyAccess
 import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
 import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
+import services.emails.EmailDefinitionsPro.ProNewCompanyAccess
 import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent
 import utils.Constants.EventType
@@ -157,7 +157,7 @@ class ProAccessTokenOrchestrator(
   def addInvitedUserAndNotify(user: User, company: Company, level: AccessLevel, invitedBy: Option[User]): Future[Unit] =
     for {
       _ <- accessTokenRepository.giveCompanyAccess(company, user, level)
-      _ <- mailService.send(ProNewCompanyAccess(user.email, company, invitedBy))
+      _ <- mailService.send(ProNewCompanyAccess.build(user.email, company, invitedBy))
       _ = logger.debug(s"User ${user.id} may now access company ${company.id}")
     } yield ()
 

--- a/app/orchestrators/ProAccessTokenOrchestrator.scala
+++ b/app/orchestrators/ProAccessTokenOrchestrator.scala
@@ -17,11 +17,11 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.Email.ProCompaniesAccessesInvitations
-import services.Email.ProCompanyAccessInvitation
-import services.Email.ProNewCompaniesAccesses
-import services.Email.ProNewCompanyAccess
-import services.MailServiceInterface
+import services.emails.Email.ProCompaniesAccessesInvitations
+import services.emails.Email.ProCompanyAccessInvitation
+import services.emails.Email.ProNewCompaniesAccesses
+import services.emails.Email.ProNewCompanyAccess
+import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent
 import utils.Constants.EventType
 import utils.EmailAddress

--- a/app/orchestrators/ReportAdminActionOrchestrator.scala
+++ b/app/orchestrators/ReportAdminActionOrchestrator.scala
@@ -19,8 +19,8 @@ import play.api.libs.json.Json
 import repositories.company.CompanyRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
-import services.Email._
-import services.MailService
+import services.emails.Email._
+import services.emails.MailService
 import utils.Constants
 import utils.Constants.ActionEvent._
 

--- a/app/orchestrators/ReportAdminActionOrchestrator.scala
+++ b/app/orchestrators/ReportAdminActionOrchestrator.scala
@@ -20,6 +20,7 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import services.emails.Email._
+import services.emails.EmailDefinitionsPro.ProReportReOpeningNotification
 import services.emails.EmailDefinitionsPro.ProResponseAcknowledgmentOnAdminCompletion
 import services.emails.MailService
 import utils.Constants
@@ -68,7 +69,7 @@ class ReportAdminActionOrchestrator(
         )
       )
       (_, users) <- getCompanyWithUsers(updatedReport)
-      _          <- users.traverse(u => mailService.send(ProReportReOpeningNotification(u.map(_.email), updatedReport)))
+      _ <- users.traverse(u => mailService.send(ProReportReOpeningNotification.build(u.map(_.email), updatedReport)))
     } yield ()
 
   private def reOpenReport(report: Report): Future[Report] = {

--- a/app/orchestrators/ReportAdminActionOrchestrator.scala
+++ b/app/orchestrators/ReportAdminActionOrchestrator.scala
@@ -20,15 +20,16 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import services.emails.Email._
+import services.emails.EmailDefinitionsPro.ProResponseAcknowledgmentOnAdminCompletion
 import services.emails.MailService
 import utils.Constants
 import utils.Constants.ActionEvent._
 
 import java.time.OffsetDateTime
 import java.util.UUID
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import scala.tools.nsc.tasty.SafeEq
 
 class ReportAdminActionOrchestrator(
@@ -179,7 +180,7 @@ class ReportAdminActionOrchestrator(
         reportAdminCompletionDetails
       )
       (maybeCompany, users) <- getCompanyWithUsers(report)
-      _ <- users.traverse(u => mailService.send(ProResponseAcknowledgmentOnAdminCompletion(report, u)))
+      _ <- users.traverse(u => mailService.send(ProResponseAcknowledgmentOnAdminCompletion.build(report, u)))
       _ <- mailService.send(ConsumerProResponseNotificationOnAdminCompletion(report, maybeCompany, messagesApi))
       _ <- eventRepository.create(
         Event(

--- a/app/orchestrators/ReportAdminActionOrchestrator.scala
+++ b/app/orchestrators/ReportAdminActionOrchestrator.scala
@@ -70,7 +70,9 @@ class ReportAdminActionOrchestrator(
         )
       )
       (_, users) <- getCompanyWithUsers(updatedReport)
-      _ <- users.traverse(u => mailService.send(ProReportReOpeningNotification.build(u.map(_.email), updatedReport)))
+      _ <- users.traverse(u =>
+        mailService.send(ProReportReOpeningNotification.EmailImpl(u.map(_.email), updatedReport))
+      )
     } yield ()
 
   private def reOpenReport(report: Report): Future[Report] = {
@@ -182,7 +184,7 @@ class ReportAdminActionOrchestrator(
         reportAdminCompletionDetails
       )
       (maybeCompany, users) <- getCompanyWithUsers(report)
-      _ <- users.traverse(u => mailService.send(ProResponseAcknowledgmentOnAdminCompletion.build(report, u)))
+      _ <- users.traverse(u => mailService.send(ProResponseAcknowledgmentOnAdminCompletion.EmailImpl(report, u)))
       _ <- mailService.send(
         ConsumerProResponseNotificationOnAdminCompletion.EmailImpl(report, maybeCompany, messagesApi)
       )

--- a/app/orchestrators/ReportAdminActionOrchestrator.scala
+++ b/app/orchestrators/ReportAdminActionOrchestrator.scala
@@ -20,6 +20,7 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import services.emails.Email._
+import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
 import services.emails.EmailDefinitionsPro.ProReportReOpeningNotification
 import services.emails.EmailDefinitionsPro.ProResponseAcknowledgmentOnAdminCompletion
 import services.emails.MailService
@@ -153,7 +154,7 @@ class ReportAdminActionOrchestrator(
       _            <- reportRepository.delete(id)
       _ <- report.companyId.map(id => reportOrchestrator.removeAccessTokenWhenNoMoreReports(id)).getOrElse(Future(()))
       _ <- createAdminDeletionReportEvent(report.companyId, user, event, reportAdminCompletionDetails)
-      _ <- mailService.send(ReportDeletionConfirmation(report, maybeCompany, messagesApi))
+      _ <- mailService.send(ConsumerReportDeletionConfirmation.EmailImpl(report, maybeCompany, messagesApi))
     } yield report
 
   private def getCompanyWithUsers(report: Report): Future[(Option[Company], Option[List[User]])] = for {

--- a/app/orchestrators/ReportAdminActionOrchestrator.scala
+++ b/app/orchestrators/ReportAdminActionOrchestrator.scala
@@ -70,9 +70,7 @@ class ReportAdminActionOrchestrator(
         )
       )
       (_, users) <- getCompanyWithUsers(updatedReport)
-      _ <- users.traverse(u =>
-        mailService.send(ProReportReOpeningNotification.EmailImpl(u.map(_.email), updatedReport))
-      )
+      _ <- users.traverse(u => mailService.send(ProReportReOpeningNotification.Email(u.map(_.email), updatedReport)))
     } yield ()
 
   private def reOpenReport(report: Report): Future[Report] = {
@@ -156,7 +154,7 @@ class ReportAdminActionOrchestrator(
       _            <- reportRepository.delete(id)
       _ <- report.companyId.map(id => reportOrchestrator.removeAccessTokenWhenNoMoreReports(id)).getOrElse(Future(()))
       _ <- createAdminDeletionReportEvent(report.companyId, user, event, reportAdminCompletionDetails)
-      _ <- mailService.send(ConsumerReportDeletionConfirmation.EmailImpl(report, maybeCompany, messagesApi))
+      _ <- mailService.send(ConsumerReportDeletionConfirmation.Email(report, maybeCompany, messagesApi))
     } yield report
 
   private def getCompanyWithUsers(report: Report): Future[(Option[Company], Option[List[User]])] = for {
@@ -184,9 +182,9 @@ class ReportAdminActionOrchestrator(
         reportAdminCompletionDetails
       )
       (maybeCompany, users) <- getCompanyWithUsers(report)
-      _ <- users.traverse(u => mailService.send(ProResponseAcknowledgmentOnAdminCompletion.EmailImpl(report, u)))
+      _ <- users.traverse(u => mailService.send(ProResponseAcknowledgmentOnAdminCompletion.Email(report, u)))
       _ <- mailService.send(
-        ConsumerProResponseNotificationOnAdminCompletion.EmailImpl(report, maybeCompany, messagesApi)
+        ConsumerProResponseNotificationOnAdminCompletion.Email(report, maybeCompany, messagesApi)
       )
       _ <- eventRepository.create(
         Event(

--- a/app/orchestrators/ReportAdminActionOrchestrator.scala
+++ b/app/orchestrators/ReportAdminActionOrchestrator.scala
@@ -19,7 +19,7 @@ import play.api.libs.json.Json
 import repositories.company.CompanyRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
-import services.emails.Email._
+import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotificationOnAdminCompletion
 import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
 import services.emails.EmailDefinitionsPro.ProReportReOpeningNotification
 import services.emails.EmailDefinitionsPro.ProResponseAcknowledgmentOnAdminCompletion
@@ -183,7 +183,9 @@ class ReportAdminActionOrchestrator(
       )
       (maybeCompany, users) <- getCompanyWithUsers(report)
       _ <- users.traverse(u => mailService.send(ProResponseAcknowledgmentOnAdminCompletion.build(report, u)))
-      _ <- mailService.send(ConsumerProResponseNotificationOnAdminCompletion(report, maybeCompany, messagesApi))
+      _ <- mailService.send(
+        ConsumerProResponseNotificationOnAdminCompletion.EmailImpl(report, maybeCompany, messagesApi)
+      )
       _ <- eventRepository.create(
         Event(
           UUID.randomUUID(),

--- a/app/orchestrators/ReportAssignmentOrchestrator.scala
+++ b/app/orchestrators/ReportAssignmentOrchestrator.scala
@@ -44,7 +44,7 @@ class ReportAssignmentOrchestrator(
         if (assigningToSelf) Future.unit
         else
           mailService.send(
-            ProReportAssignedNotification.EmailImpl(reportWithMetadata.report, assigningUser, newAssignedUser)
+            ProReportAssignedNotification.Email(reportWithMetadata.report, assigningUser, newAssignedUser)
           )
     } yield newAssignedUser
   }

--- a/app/orchestrators/ReportAssignmentOrchestrator.scala
+++ b/app/orchestrators/ReportAssignmentOrchestrator.scala
@@ -11,7 +11,7 @@ import play.api.Logger
 import repositories.event.EventRepositoryInterface
 import repositories.reportmetadata.ReportMetadataRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.Email.ProReportAssignedNotification
+import services.emails.EmailDefinitionsPro.ProReportAssignedNotification
 import services.emails.MailService
 import utils.Constants
 
@@ -42,7 +42,10 @@ class ReportAssignmentOrchestrator(
       _                       <- createAssignmentEvent(reportWithMetadata.report, assigningUser, newAssignedUser)
       _ <-
         if (assigningToSelf) Future.unit
-        else mailService.send(ProReportAssignedNotification(reportWithMetadata.report, assigningUser, newAssignedUser))
+        else
+          mailService.send(
+            ProReportAssignedNotification.EmailImpl(reportWithMetadata.report, assigningUser, newAssignedUser)
+          )
     } yield newAssignedUser
   }
 

--- a/app/orchestrators/ReportAssignmentOrchestrator.scala
+++ b/app/orchestrators/ReportAssignmentOrchestrator.scala
@@ -11,8 +11,8 @@ import play.api.Logger
 import repositories.event.EventRepositoryInterface
 import repositories.reportmetadata.ReportMetadataRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.Email.ProReportAssignedNotification
-import services.MailService
+import services.emails.Email.ProReportAssignedNotification
+import services.emails.MailService
 import utils.Constants
 
 import java.time.OffsetDateTime

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -126,7 +126,7 @@ class ReportOrchestrator(
           logger.debug("Found user, sending notification")
           val companyUserEmails: NonEmptyList[EmailAddress] = companyUsers.map(_.email)
           for {
-            _ <- mailService.send(ProNewReportNotification.build(companyUserEmails, report))
+            _ <- mailService.send(ProNewReportNotification.EmailImpl(companyUserEmails, report))
             reportWithUpdatedStatus <- reportRepository.update(
               report.id,
               report.copy(status = ReportStatus.TraitementEnCours)
@@ -757,7 +757,7 @@ class ReportOrchestrator(
       user: User,
       maybeCompany: Option[Company]
   ) = for {
-    _ <- mailService.send(ProResponseAcknowledgment.build(report, reportResponse, user))
+    _ <- mailService.send(ProResponseAcknowledgment.EmailImpl(report, reportResponse, user))
     _ <- mailService.send(ConsumerProResponseNotification.EmailImpl(report, reportResponse, maybeCompany, messagesApi))
   } yield ()
 

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -37,6 +37,7 @@ import repositories.subscription.SubscriptionRepositoryInterface
 import repositories.user.UserRepositoryInterface
 import repositories.website.WebsiteRepositoryInterface
 import services.emails.Email._
+import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
 import services.emails.MailService
 import tasks.company.CompanySyncServiceInterface
 import utils.Constants.ActionEvent._
@@ -328,7 +329,7 @@ class ReportOrchestrator(
       } else Future(Seq())
     _ <-
       if (ddEmails.nonEmpty) {
-        mailService.send(DgccrfDangerousProductReportNotification(ddEmails, report))
+        mailService.send(DgccrfDangerousProductReportNotification.build(ddEmails, report))
       } else {
         Future.unit
       }

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -126,7 +126,7 @@ class ReportOrchestrator(
           logger.debug("Found user, sending notification")
           val companyUserEmails: NonEmptyList[EmailAddress] = companyUsers.map(_.email)
           for {
-            _ <- mailService.send(ProNewReportNotification.EmailImpl(companyUserEmails, report))
+            _ <- mailService.send(ProNewReportNotification.Email(companyUserEmails, report))
             reportWithUpdatedStatus <- reportRepository.update(
               report.id,
               report.copy(status = ReportStatus.TraitementEnCours)
@@ -329,7 +329,7 @@ class ReportOrchestrator(
       } else Future(Seq())
     _ <-
       if (ddEmails.nonEmpty) {
-        mailService.send(DgccrfDangerousProductReportNotification.EmailImpl(ddEmails, report))
+        mailService.send(DgccrfDangerousProductReportNotification.Email(ddEmails, report))
       } else {
         Future.unit
       }
@@ -347,7 +347,7 @@ class ReportOrchestrator(
     )
     for {
       _ <- mailService.send(
-        ConsumerReportAcknowledgment.EmailImpl(report, maybeCompany, event, reportAttachements, messagesApi)
+        ConsumerReportAcknowledgment.Email(report, maybeCompany, event, reportAttachements, messagesApi)
       )
       _ <- eventRepository.create(event)
     } yield ()
@@ -737,7 +737,7 @@ class ReportOrchestrator(
 
   private def notifyConsumer(report: Report) = for {
     maybeCompany <- report.companySiret.map(companyRepository.findBySiret(_)).flatSequence
-    _            <- mailService.send(ConsumerReportReadByProNotification.EmailImpl(report, maybeCompany, messagesApi))
+    _            <- mailService.send(ConsumerReportReadByProNotification.Email(report, maybeCompany, messagesApi))
     _ <- eventRepository.create(
       Event(
         id = UUID.randomUUID(),
@@ -757,8 +757,8 @@ class ReportOrchestrator(
       user: User,
       maybeCompany: Option[Company]
   ) = for {
-    _ <- mailService.send(ProResponseAcknowledgment.EmailImpl(report, reportResponse, user))
-    _ <- mailService.send(ConsumerProResponseNotification.EmailImpl(report, reportResponse, maybeCompany, messagesApi))
+    _ <- mailService.send(ProResponseAcknowledgment.Email(report, reportResponse, user))
+    _ <- mailService.send(ConsumerProResponseNotification.Email(report, reportResponse, maybeCompany, messagesApi))
   } yield ()
 
   // dead code ?

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -38,6 +38,7 @@ import repositories.user.UserRepositoryInterface
 import repositories.website.WebsiteRepositoryInterface
 import services.emails.Email._
 import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
+import services.emails.EmailDefinitionsConsumer.ConsumerReportReadByProNotification
 import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
 import services.emails.EmailDefinitionsPro.ProNewReportNotification
 import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
@@ -736,7 +737,7 @@ class ReportOrchestrator(
 
   private def notifyConsumer(report: Report) = for {
     maybeCompany <- report.companySiret.map(companyRepository.findBySiret(_)).flatSequence
-    _            <- mailService.send(ConsumerReportReadByProNotification(report, maybeCompany, messagesApi))
+    _            <- mailService.send(ConsumerReportReadByProNotification.EmailImpl(report, maybeCompany, messagesApi))
     _ <- eventRepository.create(
       Event(
         id = UUID.randomUUID(),

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -36,7 +36,7 @@ import repositories.socialnetwork.SocialNetworkRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
 import repositories.user.UserRepositoryInterface
 import repositories.website.WebsiteRepositoryInterface
-import services.emails.Email._
+import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotification
 import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
 import services.emails.EmailDefinitionsConsumer.ConsumerReportReadByProNotification
 import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
@@ -758,7 +758,7 @@ class ReportOrchestrator(
       maybeCompany: Option[Company]
   ) = for {
     _ <- mailService.send(ProResponseAcknowledgment.build(report, reportResponse, user))
-    _ <- mailService.send(ConsumerProResponseNotification(report, reportResponse, maybeCompany, messagesApi))
+    _ <- mailService.send(ConsumerProResponseNotification.EmailImpl(report, reportResponse, maybeCompany, messagesApi))
   } yield ()
 
   // dead code ?

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -21,7 +21,6 @@ import models.report.ReportWordOccurrence.StopWords
 import models.report._
 import models.report.reportmetadata.ReportWithMetadata
 import models.token.TokenKind.CompanyInit
-import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
 import models.website.Website
 import play.api.Logger
 import play.api.i18n.MessagesApi
@@ -39,6 +38,8 @@ import repositories.user.UserRepositoryInterface
 import repositories.website.WebsiteRepositoryInterface
 import services.emails.Email._
 import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
+import services.emails.EmailDefinitionsPro.ProNewReportNotification
+import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
 import services.emails.MailService
 import tasks.company.CompanySyncServiceInterface
 import utils.Constants.ActionEvent._
@@ -123,7 +124,7 @@ class ReportOrchestrator(
           logger.debug("Found user, sending notification")
           val companyUserEmails: NonEmptyList[EmailAddress] = companyUsers.map(_.email)
           for {
-            _ <- mailService.send(ProNewReportNotification(companyUserEmails, report))
+            _ <- mailService.send(ProNewReportNotification.build(companyUserEmails, report))
             reportWithUpdatedStatus <- reportRepository.update(
               report.id,
               report.copy(status = ReportStatus.TraitementEnCours)

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -17,10 +17,11 @@ import models.company.Address
 import models.company.Company
 import models.event.Event
 import models.event.Event._
-import models.report._
 import models.report.ReportWordOccurrence.StopWords
+import models.report._
 import models.report.reportmetadata.ReportWithMetadata
 import models.token.TokenKind.CompanyInit
+import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
 import models.website.Website
 import play.api.Logger
 import play.api.i18n.MessagesApi
@@ -43,11 +44,7 @@ import tasks.company.CompanySyncServiceInterface
 import utils.Constants.ActionEvent._
 import utils.Constants.ActionEvent
 import utils.Constants.EventType
-import utils.Constants
-import utils.Country
-import utils.EmailAddress
-import utils.SIRET
-import utils.URL
+import utils._
 
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -755,7 +752,7 @@ class ReportOrchestrator(
       user: User,
       maybeCompany: Option[Company]
   ) = for {
-    _ <- mailService.send(ProResponseAcknowledgment(report, reportResponse, user))
+    _ <- mailService.send(ProResponseAcknowledgment.build(report, reportResponse, user))
     _ <- mailService.send(ConsumerProResponseNotification(report, reportResponse, maybeCompany, messagesApi))
   } yield ()
 

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -37,6 +37,7 @@ import repositories.subscription.SubscriptionRepositoryInterface
 import repositories.user.UserRepositoryInterface
 import repositories.website.WebsiteRepositoryInterface
 import services.emails.Email._
+import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
 import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
 import services.emails.EmailDefinitionsPro.ProNewReportNotification
 import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
@@ -344,7 +345,9 @@ class ReportOrchestrator(
       Constants.ActionEvent.EMAIL_CONSUMER_ACKNOWLEDGMENT
     )
     for {
-      _ <- mailService.send(ConsumerReportAcknowledgment(report, maybeCompany, event, reportAttachements, messagesApi))
+      _ <- mailService.send(
+        ConsumerReportAcknowledgment.EmailImpl(report, maybeCompany, event, reportAttachements, messagesApi)
+      )
       _ <- eventRepository.create(event)
     } yield ()
   }

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -36,8 +36,8 @@ import repositories.socialnetwork.SocialNetworkRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
 import repositories.user.UserRepositoryInterface
 import repositories.website.WebsiteRepositoryInterface
-import services.Email._
-import services.MailService
+import services.emails.Email._
+import services.emails.MailService
 import tasks.company.CompanySyncServiceInterface
 import utils.Constants.ActionEvent._
 import utils.Constants.ActionEvent

--- a/app/orchestrators/ReportOrchestrator.scala
+++ b/app/orchestrators/ReportOrchestrator.scala
@@ -329,7 +329,7 @@ class ReportOrchestrator(
       } else Future(Seq())
     _ <-
       if (ddEmails.nonEmpty) {
-        mailService.send(DgccrfDangerousProductReportNotification.build(ddEmails, report))
+        mailService.send(DgccrfDangerousProductReportNotification.EmailImpl(ddEmails, report))
       } else {
         Future.unit
       }

--- a/app/services/Email.scala
+++ b/app/services/Email.scala
@@ -46,17 +46,8 @@ sealed trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
 sealed trait ConsumerEmail extends Email
 
 object Email {
-  // ======= Divers =======
+  // ======= Admin =======
 
-  final case class UpdateEmailAddress(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int)
-      extends Email {
-
-    override val recipients: Seq[EmailAddress] = List(recipient)
-    override val subject: String               = EmailSubjects.UPDATE_EMAIL_ADDRESS
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-      views.html.mails.updateEmailAddress(invitationUrl, daysBeforeExpiry).toString()
-  }
   final case class AdminAccessLink(recipient: EmailAddress, invitationUrl: URI) extends AdminEmail {
     override val subject: String = EmailSubjects.ADMIN_ACCESS_LINK
 

--- a/app/services/Email.scala
+++ b/app/services/Email.scala
@@ -4,7 +4,6 @@ import cats.data.NonEmptyList
 import models.EmailValidation
 import models.Subscription
 import models.User
-import models.auth.AuthToken
 import models.company.Company
 import models.event.Event
 import models.report.Report
@@ -26,7 +25,7 @@ import java.time.LocalDate
 import java.time.Period
 import java.util.Locale
 
-sealed trait Email {
+trait Email {
   val recipients: Seq[EmailAddress]
   val subject: String
   def getBody: (FrontRoute, EmailAddress) => String
@@ -48,14 +47,6 @@ sealed trait ConsumerEmail extends Email
 
 object Email {
   // ======= Divers =======
-
-  final case class ResetPassword(user: User, authToken: AuthToken) extends ProEmail with DgccrfEmail {
-    override val recipients: List[EmailAddress] = List(user.email)
-    override val subject: String                = EmailSubjects.RESET_PASSWORD
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
-      views.html.mails.resetPassword(user, authToken)(frontRoute, contactAddress).toString
-  }
 
   final case class UpdateEmailAddress(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int)
       extends Email {

--- a/app/services/Emails.scala
+++ b/app/services/Emails.scala
@@ -10,6 +10,8 @@ import utils.EmailAddress
 import utils.EmailSubjects
 import utils.FrontRoute
 
+import java.net.URI
+
 sealed trait EmailCategory extends EnumEntry
 
 object EmailCategory extends PlayEnum[EmailCategory] {
@@ -44,6 +46,21 @@ object EmailDefinitions {
         override val subject: String                = EmailSubjects.RESET_PASSWORD
         override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
           views.html.mails.resetPassword(user, authToken)(frontRoute, contactAddress).toString
+      }
+  }
+
+  case object UpdateEmailAddress extends EmailDefinition {
+    override val category = Various
+
+    override def examples =
+      Seq("update_email_address" -> (recipient => build(recipient, dummyURL, daysBeforeExpiry = 2)))
+
+    def build(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int): Email =
+      new Email {
+        override val recipients: List[EmailAddress] = List(recipient)
+        override val subject: String                = EmailSubjects.UPDATE_EMAIL_ADDRESS
+        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+          views.html.mails.updateEmailAddress(invitationUrl, daysBeforeExpiry).toString()
       }
   }
 

--- a/app/services/Emails.scala
+++ b/app/services/Emails.scala
@@ -1,0 +1,50 @@
+package services
+
+import enumeratum.EnumEntry
+import enumeratum.PlayEnum
+import models.User
+import models.auth.AuthToken
+import services.EmailCategory.Various
+import services.EmailsExamplesUtils._
+import utils.EmailAddress
+import utils.EmailSubjects
+import utils.FrontRoute
+
+sealed trait EmailCategory extends EnumEntry
+
+object EmailCategory extends PlayEnum[EmailCategory] {
+  override def values: IndexedSeq[EmailCategory] = findValues
+
+  case object Various extends EmailCategory
+
+  case object Admin extends EmailCategory
+
+  case object Dgccrf extends EmailCategory
+  case object Pro    extends EmailCategory
+  case object Conso  extends EmailCategory
+
+}
+
+trait EmailDefinition {
+  val category: EmailCategory
+  def examples: Seq[(String, EmailAddress => Email)]
+
+}
+
+object EmailDefinitions {
+
+  case object ResetPassword extends EmailDefinition {
+    override val category = Various
+    override def examples =
+      Seq("reset_password" -> (recipient => build(genUser.copy(email = recipient), genAuthToken)))
+
+    def build(user: User, authToken: AuthToken): Email =
+      new Email {
+        override val recipients: List[EmailAddress] = List(user.email)
+        override val subject: String                = EmailSubjects.RESET_PASSWORD
+        override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
+          views.html.mails.resetPassword(user, authToken)(frontRoute, contactAddress).toString
+      }
+  }
+
+}

--- a/app/services/EmailsExamplesUtils.scala
+++ b/app/services/EmailsExamplesUtils.scala
@@ -1,0 +1,143 @@
+package services
+
+import models.Subscription
+import models.User
+import models.UserRole
+import models.auth.AuthToken
+import models.company.Address
+import models.company.Company
+import models.event.Event
+import models.report.DetailInputValue.toDetailInputValue
+import models.report.ReportFileOrigin.Consumer
+import models.report.Gender
+import models.report.Report
+import models.report.ReportFile
+import models.report.ReportResponse
+import models.report.ReportResponseType
+import models.report.ReportStatus
+import models.report.ResponseDetails
+import models.report.WebsiteURL
+import models.report.reportfile.ReportFileId
+import utils.Constants.ActionEvent.POST_ACCOUNT_ACTIVATION_DOC
+import utils.Constants.EventType
+import utils.EmailAddress
+import utils.SIREN
+import utils.SIRET
+
+import java.time.OffsetDateTime
+import java.util.Locale
+import java.util.UUID
+
+object EmailsExamplesUtils {
+
+  val dummyURL = java.net.URI.create("https://lien-test")
+
+  def genReport = Report(
+    id = UUID.fromString("c1cbadb3-04d8-4765-9500-796e7c1f2a6c"),
+    gender = Some(Gender.Female),
+    category = "Test",
+    subcategories = List("test"),
+    details = List(toDetailInputValue("test")),
+    companyId = Some(UUID.randomUUID()),
+    companyName = Some("Dummy Inc."),
+    companyBrand = Some("Dummy Inc. Store"),
+    companyAddress = Address(Some("3 bis"), Some("Rue des exemples"), None, Some("13006"), Some("Douceville")),
+    companySiret = Some(SIRET("12345678912345")),
+    companyActivityCode = None,
+    websiteURL = WebsiteURL(None, None),
+    phone = None,
+    creationDate = OffsetDateTime.now(),
+    firstName = "John",
+    lastName = "Doe",
+    email = EmailAddress("john.doe@example.com"),
+    contactAgreement = true,
+    employeeConsumer = false,
+    status = ReportStatus.TraitementEnCours,
+    expirationDate = OffsetDateTime.now().plusDays(50),
+    influencer = None,
+    visibleToPro = true,
+    lang = Some(Locale.FRENCH),
+    barcodeProductId = None,
+    train = None,
+    station = None
+  )
+
+  def genReportFile = ReportFile(
+    id = ReportFileId.generateId(),
+    reportId = Some(UUID.fromString("c1cbadb3-04d8-4765-9500-796e7c1f2a6c")),
+    creationDate = OffsetDateTime.now(),
+    filename = s"${UUID.randomUUID.toString}.png",
+    storageFilename = "String",
+    origin = Consumer,
+    avOutput = None
+  )
+
+  def genReportResponse = ReportResponse(
+    responseType = ReportResponseType.ACCEPTED,
+    responseDetails = Some(ResponseDetails.REFUND),
+    otherResponseDetails = None,
+    consumerDetails = "",
+    dgccrfDetails = Some(""),
+    fileIds = Nil
+  )
+
+  def genCompany = Company(
+    id = UUID.randomUUID,
+    siret = SIRET.fromUnsafe("12345678901234"),
+    creationDate = OffsetDateTime.now(),
+    name = "Test Entreprise",
+    address = Address(
+      number = Some("3"),
+      street = Some("rue des Champs"),
+      postalCode = Some("75015"),
+      city = Some("Paris"),
+      country = None
+    ),
+    activityCode = None,
+    isHeadOffice = true,
+    isOpen = true,
+    isPublic = true,
+    brand = Some("une super enseigne")
+  )
+
+  def genCompanyList = List(genCompany, genCompany, genCompany)
+
+  def genSiren = SIREN.fromSIRET(genCompany.siret)
+
+  def genUser = User(
+    id = UUID.randomUUID,
+    password = "",
+    email = EmailAddress("text@example.com"),
+    firstName = "Jeanne",
+    lastName = "Dupont",
+    userRole = UserRole.Admin,
+    lastEmailValidation = None
+  )
+
+  def genEvent =
+    Event(
+      UUID.randomUUID(),
+      None,
+      None,
+      None,
+      OffsetDateTime.now(),
+      EventType.PRO,
+      POST_ACCOUNT_ACTIVATION_DOC
+    )
+
+  def genSubscription = Subscription(
+    id = UUID.randomUUID,
+    userId = None,
+    email = None,
+    departments = List("75"),
+    countries = Nil,
+    withTags = Nil,
+    withoutTags = Nil,
+    categories = Nil,
+    sirets = Nil,
+    frequency = java.time.Period.ofDays(1)
+  )
+
+  def genAuthToken =
+    AuthToken(UUID.randomUUID, UUID.randomUUID, OffsetDateTime.now().plusDays(10))
+}

--- a/app/services/emails/BaseEmail.scala
+++ b/app/services/emails/BaseEmail.scala
@@ -6,14 +6,14 @@ import services.AttachmentService
 import utils.EmailAddress
 import utils.FrontRoute
 
-trait Email {
+trait BaseEmail {
   val recipients: Seq[EmailAddress]
   val subject: String
   def getBody: (FrontRoute, EmailAddress) => String
   def getAttachements: AttachmentService => Seq[Attachment] = _.defaultAttachments
 }
 
-sealed trait ProFilteredEmail extends Email
+sealed trait ProFilteredEmail extends BaseEmail
 trait ProFilteredEmailSingleReport extends ProFilteredEmail {
   val report: Report
 }

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -28,9 +28,6 @@ trait Email {
   def getAttachements: AttachmentService => Seq[Attachment] = _.defaultAttachments
 }
 
-sealed trait AdminEmail  extends Email
-sealed trait DgccrfEmail extends Email
-
 sealed trait ProEmail         extends Email
 sealed trait ProFilteredEmail extends ProEmail
 trait ProFilteredEmailSingleReport extends ProFilteredEmail {
@@ -44,15 +41,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= PRO =======
-
-  final case class ProResponseAcknowledgmentOnAdminCompletion(report: Report, users: List[User])
-      extends ProFilteredEmailSingleReport {
-    override val recipients: List[EmailAddress] = users.map(_.email)
-    override val subject: String                = EmailSubjects.REPORT_ACK_PRO_ON_ADMIN_COMPLETION
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) => views.html.mails.professional.reportAcknowledgmentProOnAdminCompletion(frontRoute).toString
-  }
 
   final case class ProNewReportNotification(userList: NonEmptyList[EmailAddress], report: Report)
       extends ProFilteredEmailSingleReport {

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -36,25 +36,6 @@ object Email {
 
   // ======= Conso =======
 
-  final case class ConsumerReportClosedNoReading(
-      report: Report,
-      maybeCompany: Option[Company],
-      messagesApi: MessagesApi
-  ) extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(report.lang))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-
-    override val recipients: List[EmailAddress] = List(report.email)
-    override val subject: String                = messagesApi("ReportClosedByNoReadingEmail.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
-      views.html.mails.consumer.reportClosedByNoReading(report, maybeCompany)(frontRoute, messagesProvider).toString
-
-    override def getAttachements: AttachmentService => Seq[Attachment] =
-      _.needWorkflowSeqForWorkflowStepN(3, report)
-
-  }
-
   final case class ConsumerReportClosedNoAction(report: Report, maybeCompany: Option[Company], messagesApi: MessagesApi)
       extends ConsumerEmail {
     private val lang                                        = Lang(getLocaleOrDefault(report.lang))

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -1,20 +1,21 @@
-package services
+package services.emails
 
 import cats.data.NonEmptyList
-import models.EmailValidation
-import models.Subscription
-import models.User
 import models.company.Company
 import models.event.Event
 import models.report.Report
 import models.report.ReportFile
 import models.report.ReportResponse
 import models.report.ReportTag
+import models.EmailValidation
+import models.Subscription
+import models.User
 import play.api.i18n.Lang
 import play.api.i18n.MessagesApi
 import play.api.i18n.MessagesImpl
 import play.api.i18n.MessagesProvider
 import play.api.libs.mailer.Attachment
+import services.AttachmentService
 import utils.EmailAddress
 import utils.EmailSubjects
 import utils.FrontRoute

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -1,6 +1,5 @@
 package services.emails
 
-import models.company.Company
 import models.report.Report
 import models.EmailValidation
 import play.api.i18n.Lang
@@ -35,22 +34,6 @@ trait ConsumerEmail extends Email
 object Email {
 
   // ======= Conso =======
-
-  final case class ConsumerReportClosedNoAction(report: Report, maybeCompany: Option[Company], messagesApi: MessagesApi)
-      extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(report.lang))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-
-    override val recipients: List[EmailAddress] = List(report.email)
-    override val subject: String                = messagesApi("ReportNotAnswered.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
-      views.html.mails.consumer.reportClosedByNoAction(report, maybeCompany)(frontRoute, messagesProvider).toString
-
-    override def getAttachements: AttachmentService => Seq[Attachment] =
-      _.needWorkflowSeqForWorkflowStepN(4, report)
-
-  }
 
   final case class ConsumerValidateEmail(
       emailValidation: EmailValidation,

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -35,22 +35,12 @@ trait ProFilteredEmailSingleReport extends ProFilteredEmail {
 trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
   val reports: List[Report]
 }
+
 sealed trait ConsumerEmail extends Email
 
 object Email {
 
   // ======= PRO =======
-
-  final case class ProReportsReadReminder(
-      recipients: List[EmailAddress],
-      reports: List[Report],
-      period: Period
-  ) extends ProFilteredEmailMultipleReport {
-    override val subject: String = EmailSubjects.REPORT_TRANSMITTED_REMINDER
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) => views.html.mails.professional.reportsTransmittedReminder(reports, period)(frontRoute).toString
-  }
 
   final case class ProReportsUnreadReminder(
       recipients: List[EmailAddress],

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -50,17 +50,6 @@ object Email {
 
   // ======= DGCCRF =======
 
-  final case class DgccrfInactiveAccount(
-      user: User,
-      expirationDate: Option[LocalDate]
-  ) extends DgccrfEmail {
-    override val recipients: Seq[EmailAddress] = List(user.email)
-    override val subject: String               = EmailSubjects.INACTIVE_DGCCRF_ACCOUNT_REMINDER
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
-      views.html.mails.dgccrf.inactiveAccount(user.fullName, expirationDate)(frontRoute).toString
-  }
-
   final case class DgccrfDangerousProductReportNotification(
       recipients: Seq[EmailAddress],
       report: Report

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -1,17 +1,10 @@
 package services.emails
 
 import models.report.Report
-import models.EmailValidation
-import play.api.i18n.Lang
-import play.api.i18n.MessagesApi
-import play.api.i18n.MessagesImpl
-import play.api.i18n.MessagesProvider
 import play.api.libs.mailer.Attachment
 import services.AttachmentService
 import utils.EmailAddress
 import utils.FrontRoute
-
-import java.util.Locale
 
 trait Email {
   val recipients: Seq[EmailAddress]
@@ -31,30 +24,4 @@ trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
 
 trait ConsumerEmail extends Email
 
-object Email {
-
-  // ======= Conso =======
-
-  final case class ConsumerValidateEmail(
-      emailValidation: EmailValidation,
-      locale: Option[Locale],
-      messagesApi: MessagesApi
-  ) extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(locale))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-
-    override val recipients: List[EmailAddress] = List(emailValidation.email)
-    override val subject: String                = messagesApi("ConsumerValidateEmail.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
-      views.html.mails.consumer
-        .confirmEmail(emailValidation.email, emailValidation.confirmationCode)(
-          frontRoute,
-          contactAddress,
-          messagesProvider
-        )
-        .toString
-  }
-
-  private def getLocaleOrDefault(locale: Option[Locale]): Locale = locale.getOrElse(Locale.FRENCH)
-}
+object Email {}

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -2,7 +2,6 @@ package services.emails
 
 import models.company.Company
 import models.report.Report
-import models.report.ReportResponse
 import models.EmailValidation
 import play.api.i18n.Lang
 import play.api.i18n.MessagesApi
@@ -36,32 +35,6 @@ trait ConsumerEmail extends Email
 object Email {
 
   // ======= Conso =======
-
-  final case class ConsumerProResponseNotification(
-      report: Report,
-      reportResponse: ReportResponse,
-      maybeCompany: Option[Company],
-      messagesApi: MessagesApi
-  ) extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(report.lang))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-
-    override val recipients: List[EmailAddress] = List(report.email)
-    override val subject: String                = messagesApi("ConsumerReportAckProEmail.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
-      views.html.mails.consumer
-        .reportToConsumerAcknowledgmentPro(
-          report,
-          maybeCompany,
-          reportResponse,
-          frontRoute.website.reportReview(report.id.toString)
-        )
-        .toString
-
-    override def getAttachements: AttachmentService => Seq[Attachment] =
-      _.ConsumerProResponseNotificationAttachement(report.lang.getOrElse(Locale.FRENCH))
-  }
 
   final case class ConsumerProResponseNotificationOnAdminCompletion(
       report: Report,

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -17,7 +17,6 @@ import utils.EmailAddress
 import utils.EmailSubjects
 import utils.FrontRoute
 
-import java.time.Period
 import java.util.Locale
 
 trait Email {
@@ -41,17 +40,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= PRO =======
-
-  final case class ProReportsUnreadReminder(
-      recipients: List[EmailAddress],
-      reports: List[Report],
-      period: Period
-  ) extends ProFilteredEmailMultipleReport {
-    override val subject: String = EmailSubjects.REPORT_UNREAD_REMINDER
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) => views.html.mails.professional.reportsUnreadReminder(reports, period)(frontRoute).toString
-  }
 
   final case class ProReportAssignedNotification(report: Report, assigningUser: User, assignedUser: User)
       extends ProFilteredEmailSingleReport {

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -33,10 +33,10 @@ sealed trait DgccrfEmail extends Email
 
 sealed trait ProEmail         extends Email
 sealed trait ProFilteredEmail extends ProEmail
-sealed trait ProFilteredEmailSingleReport extends ProFilteredEmail {
+trait ProFilteredEmailSingleReport extends ProFilteredEmail {
   val report: Report
 }
-sealed trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
+trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
   val reports: List[Report]
 }
 sealed trait ConsumerEmail extends Email
@@ -44,16 +44,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= PRO =======
-
-  final case class ProResponseAcknowledgment(report: Report, reportResponse: ReportResponse, user: User)
-      extends ProFilteredEmailSingleReport {
-    override val recipients: List[EmailAddress] = List(user.email)
-    override val subject: String                = EmailSubjects.REPORT_ACK_PRO
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) =>
-        views.html.mails.professional.reportAcknowledgmentPro(reportResponse, user)(frontRoute).toString
-  }
 
   final case class ProResponseAcknowledgmentOnAdminCompletion(report: Report, users: List[User])
       extends ProFilteredEmailSingleReport {

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -46,21 +46,6 @@ object Email {
 
   // ======= PRO =======
 
-  final case class ProNewCompanyAccess(
-      recipient: EmailAddress,
-      company: Company,
-      invitedBy: Option[User]
-  ) extends ProEmail {
-    override val recipients: List[EmailAddress] = List(recipient)
-    override val subject: String                = EmailSubjects.NEW_COMPANY_ACCESS(company.name)
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) =>
-        views.html.mails.professional
-          .newCompanyAccessNotification(frontRoute.dashboard.login, company, invitedBy)(frontRoute)
-          .toString
-  }
-
   final case class ProNewCompaniesAccesses(
       recipient: EmailAddress,
       companies: List[Company],

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -50,16 +50,6 @@ object Email {
 
   // ======= DGCCRF =======
 
-  final case class DgccrfDangerousProductReportNotification(
-      recipients: Seq[EmailAddress],
-      report: Report
-  ) extends DgccrfEmail {
-    override val subject: String = EmailSubjects.REPORT_NOTIF_DGCCRF(1, Some("[Produits dangereux] "))
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contact) =>
-      views.html.mails.dgccrf.reportDangerousProductNotification(report)(frontRoute, contact).toString
-  }
-
   final case class DgccrfReportNotification(
       recipients: List[EmailAddress],
       subscription: Subscription,

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -13,15 +13,10 @@ trait Email {
   def getAttachements: AttachmentService => Seq[Attachment] = _.defaultAttachments
 }
 
-sealed trait ProEmail         extends Email
-sealed trait ProFilteredEmail extends ProEmail
+sealed trait ProFilteredEmail extends Email
 trait ProFilteredEmailSingleReport extends ProFilteredEmail {
   val report: Report
 }
 trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
   val reports: List[Report]
 }
-
-trait ConsumerEmail extends Email
-
-object Email {}

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -36,29 +36,6 @@ object Email {
 
   // ======= Conso =======
 
-  final case class ConsumerProResponseNotificationOnAdminCompletion(
-      report: Report,
-      maybeCompany: Option[Company],
-      messagesApi: MessagesApi
-  ) extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(report.lang))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-
-    override val recipients: List[EmailAddress] = List(report.email)
-    override val subject: String = messagesApi("ConsumerReportAckProEmailOnAdminCompletion.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-      views.html.mails.consumer
-        .reportToConsumerAcknowledgmentOnAdminCompletion(
-          report,
-          maybeCompany
-        )
-        .toString
-
-    override def getAttachements: AttachmentService => Seq[Attachment] =
-      s => s.defaultAttachments ++ s.attachmentSeqForWorkflowStepN(4, report.lang.getOrElse(Locale.FRENCH))
-  }
-
   final case class ConsumerReportClosedNoReading(
       report: Report,
       maybeCompany: Option[Company],

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -1,9 +1,7 @@
 package services.emails
 
 import models.company.Company
-import models.event.Event
 import models.report.Report
-import models.report.ReportFile
 import models.report.ReportResponse
 import models.EmailValidation
 import play.api.i18n.Lang
@@ -38,28 +36,6 @@ trait ConsumerEmail extends Email
 object Email {
 
   // ======= Conso =======
-
-  final case class ConsumerReportAcknowledgment(
-      report: Report,
-      maybeCompany: Option[Company],
-      event: Event,
-      files: Seq[ReportFile],
-      messagesApi: MessagesApi
-  ) extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(report.lang))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-
-    override val recipients: List[EmailAddress] = List(report.email)
-    override val subject: String                = messagesApi("ReportAckEmail.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
-      views.html.mails.consumer
-        .reportAcknowledgment(report, maybeCompany, files.toList)(frontRoute, messagesProvider)
-        .toString
-
-    override def getAttachements: AttachmentService => Seq[Attachment] =
-      _.reportAcknowledgmentAttachement(report, maybeCompany, event, files, messagesProvider)
-  }
 
   final case class ConsumerReportReadByProNotification(
       report: Report,

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -17,7 +17,6 @@ import services.AttachmentService
 import utils.EmailAddress
 import utils.EmailSubjects
 import utils.FrontRoute
-import utils.SIREN
 
 import java.time.Period
 import java.util.Locale
@@ -45,21 +44,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= PRO =======
-
-  final case class ProNewCompaniesAccesses(
-      recipient: EmailAddress,
-      companies: List[Company],
-      siren: SIREN
-  ) extends ProEmail {
-    override val recipients: List[EmailAddress] = List(recipient)
-    override val subject: String                = EmailSubjects.PRO_NEW_COMPANIES_ACCESSES(siren)
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) =>
-        views.html.mails.professional
-          .newCompaniesAccessesNotification(frontRoute.dashboard.login, companies, siren.value)(frontRoute)
-          .toString
-  }
 
   final case class ProResponseAcknowledgment(report: Report, reportResponse: ReportResponse, user: User)
       extends ProFilteredEmailSingleReport {

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -41,15 +41,6 @@ object Email {
 
   // ======= PRO =======
 
-  final case class ProReportReOpeningNotification(userList: List[EmailAddress], report: Report)
-      extends ProFilteredEmailSingleReport {
-    override val subject: String                = EmailSubjects.REPORT_REOPENING
-    override val recipients: List[EmailAddress] = userList.toList
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) => views.html.mails.professional.reportReOpening(report)(frontRoute).toString
-  }
-
   final case class ProReportsReadReminder(
       recipients: List[EmailAddress],
       reports: List[Report],

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -50,16 +50,6 @@ object Email {
 
   // ======= DGCCRF =======
 
-  final case class DgccrfAgentAccessLink(role: String)(recipient: EmailAddress, invitationUrl: URI)
-      extends DgccrfEmail {
-    override val subject: String = EmailSubjects.DGCCRF_ACCESS_LINK
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-      views.html.mails.dgccrf.accessLink(invitationUrl, role).toString
-
-    override val recipients: List[EmailAddress] = List(recipient)
-  }
-
   final case class DgccrfInactiveAccount(
       user: User,
       expirationDate: Option[LocalDate]

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -1,6 +1,5 @@
 package services.emails
 
-import cats.data.NonEmptyList
 import models.company.Company
 import models.event.Event
 import models.report.Report
@@ -41,15 +40,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= PRO =======
-
-  final case class ProNewReportNotification(userList: NonEmptyList[EmailAddress], report: Report)
-      extends ProFilteredEmailSingleReport {
-    override val subject: String                = EmailSubjects.NEW_REPORT
-    override val recipients: List[EmailAddress] = userList.toList
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (frontRoute, _) => views.html.mails.professional.reportNotification(report)(frontRoute).toString
-  }
 
   final case class ProReportReOpeningNotification(userList: List[EmailAddress], report: Report)
       extends ProFilteredEmailSingleReport {

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -37,24 +37,6 @@ object Email {
 
   // ======= Conso =======
 
-  final case class ConsumerReportReadByProNotification(
-      report: Report,
-      maybeCompany: Option[Company],
-      messagesApi: MessagesApi
-  ) extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(report.lang))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-
-    override val recipients: List[EmailAddress] = List(report.email)
-    override val subject: String                = messagesApi("ConsumerReportTransmittedEmail.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-      views.html.mails.consumer.reportTransmission(report, maybeCompany).toString
-
-    override def getAttachements: AttachmentService => Seq[Attachment] =
-      _.attachmentSeqForWorkflowStepN(3, report.lang.getOrElse(Locale.FRENCH))
-  }
-
   final case class ConsumerProResponseNotification(
       report: Report,
       reportResponse: ReportResponse,

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -6,9 +6,7 @@ import models.event.Event
 import models.report.Report
 import models.report.ReportFile
 import models.report.ReportResponse
-import models.report.ReportTag
 import models.EmailValidation
-import models.Subscription
 import models.User
 import play.api.i18n.Lang
 import play.api.i18n.MessagesApi
@@ -22,7 +20,6 @@ import utils.FrontRoute
 import utils.SIREN
 
 import java.net.URI
-import java.time.LocalDate
 import java.time.Period
 import java.util.Locale
 
@@ -49,21 +46,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= DGCCRF =======
-
-  final case class DgccrfReportNotification(
-      recipients: List[EmailAddress],
-      subscription: Subscription,
-      reports: Seq[(Report, List[ReportFile])],
-      startDate: LocalDate
-  ) extends DgccrfEmail {
-    override val subject: String = EmailSubjects.REPORT_NOTIF_DGCCRF(
-      reports.length,
-      subscription.withTags.find(_ == ReportTag.ProduitDangereux).map(_ => "[Produits dangereux] ")
-    )
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contact) =>
-      views.html.mails.dgccrf.reportNotification(subscription, reports, startDate)(frontRoute, contact).toString
-  }
 
   final case class DgccrfValidateEmail(email: EmailAddress, daysBeforeExpiry: Int, validationUrl: URI)
       extends DgccrfEmail {

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -19,7 +19,6 @@ import utils.EmailSubjects
 import utils.FrontRoute
 import utils.SIREN
 
-import java.net.URI
 import java.time.Period
 import java.util.Locale
 
@@ -46,20 +45,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= PRO =======
-
-  final case class ProCompaniesAccessesInvitations(
-      recipient: EmailAddress,
-      companies: List[Company],
-      siren: SIREN,
-      invitationUrl: URI
-  ) extends ProEmail {
-    override val recipients: List[EmailAddress] = List(recipient)
-    override val subject: String                = EmailSubjects.PRO_COMPANIES_ACCESSES_INVITATIONS(siren)
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (_, _) =>
-        views.html.mails.professional.companiesAccessesInvitations(invitationUrl, companies, siren.value).toString
-  }
 
   final case class ProNewCompanyAccess(
       recipient: EmailAddress,

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -6,7 +6,6 @@ import models.report.Report
 import models.report.ReportFile
 import models.report.ReportResponse
 import models.EmailValidation
-import models.User
 import play.api.i18n.Lang
 import play.api.i18n.MessagesApi
 import play.api.i18n.MessagesImpl
@@ -14,7 +13,6 @@ import play.api.i18n.MessagesProvider
 import play.api.libs.mailer.Attachment
 import services.AttachmentService
 import utils.EmailAddress
-import utils.EmailSubjects
 import utils.FrontRoute
 
 import java.util.Locale
@@ -40,16 +38,6 @@ sealed trait ConsumerEmail extends Email
 object Email {
 
   // ======= PRO =======
-
-  final case class ProReportAssignedNotification(report: Report, assigningUser: User, assignedUser: User)
-      extends ProFilteredEmailSingleReport {
-    override val recipients: List[EmailAddress] = List(assignedUser.email)
-    override val subject: String                = EmailSubjects.REPORT_ASSIGNED
-
-    override def getBody: (FrontRoute, EmailAddress) => String = { (frontRoute, _) =>
-      views.html.mails.professional.reportAssigned(report, assigningUser, assignedUser)(frontRoute).toString
-    }
-  }
 
   final case class ReportDeletionConfirmation(report: Report, maybeCompany: Option[Company], messagesApi: MessagesApi)
       extends ConsumerEmail {

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -45,17 +45,6 @@ sealed trait ConsumerEmail extends Email
 
 object Email {
 
-  // ======= DGCCRF =======
-
-  final case class DgccrfValidateEmail(email: EmailAddress, daysBeforeExpiry: Int, validationUrl: URI)
-      extends DgccrfEmail {
-    override val recipients: List[EmailAddress] = List(email)
-    override val subject: String                = EmailSubjects.VALIDATE_EMAIL
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-      views.html.mails.validateEmail(validationUrl, daysBeforeExpiry).toString
-  }
-
   // ======= PRO =======
 
   final case class ProCompanyAccessInvitation(

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -47,19 +47,6 @@ object Email {
 
   // ======= PRO =======
 
-  final case class ProCompanyAccessInvitation(
-      recipient: EmailAddress,
-      company: Company,
-      invitationUrl: URI,
-      invitedBy: Option[User]
-  ) extends ProEmail {
-    override val recipients: List[EmailAddress] = List(recipient)
-    override val subject: String                = EmailSubjects.COMPANY_ACCESS_INVITATION(company.name)
-
-    override def getBody: (FrontRoute, EmailAddress) => String =
-      (_, _) => views.html.mails.professional.companyAccessInvitation(invitationUrl, company, invitedBy).toString
-  }
-
   final case class ProCompaniesAccessesInvitations(
       recipient: EmailAddress,
       companies: List[Company],

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -47,25 +47,6 @@ sealed trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
 sealed trait ConsumerEmail extends Email
 
 object Email {
-  // ======= Admin =======
-
-  final case class AdminAccessLink(recipient: EmailAddress, invitationUrl: URI) extends AdminEmail {
-    override val subject: String = EmailSubjects.ADMIN_ACCESS_LINK
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-      views.html.mails.admin.accessLink(invitationUrl).toString
-
-    override val recipients: List[EmailAddress] = List(recipient)
-  }
-
-  final case class AdminProbeTriggered(recipients: Seq[EmailAddress], probeName: String, rate: Double, issue: String)
-      extends AdminEmail {
-
-    override val subject: String = EmailSubjects.ADMIN_PROBE_TRIGGERED
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-      views.html.mails.admin.probetriggered(probeName, rate, issue).toString()
-  }
 
   // ======= DGCCRF =======
 

--- a/app/services/emails/Email.scala
+++ b/app/services/emails/Email.scala
@@ -33,24 +33,9 @@ trait ProFilteredEmailMultipleReport extends ProFilteredEmail {
   val reports: List[Report]
 }
 
-sealed trait ConsumerEmail extends Email
+trait ConsumerEmail extends Email
 
 object Email {
-
-  // ======= PRO =======
-
-  final case class ReportDeletionConfirmation(report: Report, maybeCompany: Option[Company], messagesApi: MessagesApi)
-      extends ConsumerEmail {
-    private val lang                                        = Lang(getLocaleOrDefault(report.lang))
-    implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
-    override val recipients: List[EmailAddress]             = List(report.email)
-    override val subject: String                            = messagesApi("ConsumerReportDeletionEmail.subject")(lang)
-
-    override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
-      views.html.mails.consumer
-        .confirmReportDeletionEmail(report, maybeCompany)(frontRoute, messagesProvider)
-        .toString
-  }
 
   // ======= Conso =======
 

--- a/app/services/emails/EmailDefinitions.scala
+++ b/app/services/emails/EmailDefinitions.scala
@@ -33,21 +33,6 @@ import services.emails.EmailDefinitionsVarious.ResetPassword
 import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import utils.EmailAddress
 
-sealed trait EmailCategory extends EnumEntry
-
-object EmailCategory extends PlayEnum[EmailCategory] {
-  override def values: IndexedSeq[EmailCategory] = findValues
-
-  case object Various extends EmailCategory
-
-  case object Admin extends EmailCategory
-
-  case object Dgccrf   extends EmailCategory
-  case object Pro      extends EmailCategory
-  case object Consumer extends EmailCategory
-
-}
-
 trait EmailDefinition {
   val category: EmailCategory
 
@@ -91,4 +76,18 @@ object EmailDefinitions {
     ConsumerReportClosedNoAction,
     ConsumerValidateEmail
   )
+}
+sealed trait EmailCategory extends EnumEntry
+
+object EmailCategory extends PlayEnum[EmailCategory] {
+  override def values: IndexedSeq[EmailCategory] = findValues
+
+  case object Various extends EmailCategory
+
+  case object Admin extends EmailCategory
+
+  case object Dgccrf   extends EmailCategory
+  case object Pro      extends EmailCategory
+  case object Consumer extends EmailCategory
+
 }

--- a/app/services/emails/EmailDefinitions.scala
+++ b/app/services/emails/EmailDefinitions.scala
@@ -2,6 +2,7 @@ package services.emails
 
 import enumeratum.EnumEntry
 import enumeratum.PlayEnum
+import play.api.i18n.MessagesApi
 import utils.EmailAddress
 
 sealed trait EmailCategory extends EnumEntry
@@ -13,15 +14,15 @@ object EmailCategory extends PlayEnum[EmailCategory] {
 
   case object Admin extends EmailCategory
 
-  case object Dgccrf extends EmailCategory
-  case object Pro    extends EmailCategory
-  case object Conso  extends EmailCategory
+  case object Dgccrf   extends EmailCategory
+  case object Pro      extends EmailCategory
+  case object Consumer extends EmailCategory
 
 }
 
 trait EmailDefinition {
   val category: EmailCategory
 
-  def examples: Seq[(String, EmailAddress => Email)]
+  def examples: Seq[(String, (EmailAddress, MessagesApi) => Email)]
 
 }

--- a/app/services/emails/EmailDefinitions.scala
+++ b/app/services/emails/EmailDefinitions.scala
@@ -1,0 +1,26 @@
+package services.emails
+
+import enumeratum.EnumEntry
+import enumeratum.PlayEnum
+import utils.EmailAddress
+
+sealed trait EmailCategory extends EnumEntry
+
+object EmailCategory extends PlayEnum[EmailCategory] {
+  override def values: IndexedSeq[EmailCategory] = findValues
+
+  case object Various extends EmailCategory
+
+  case object Admin extends EmailCategory
+
+  case object Dgccrf extends EmailCategory
+  case object Pro    extends EmailCategory
+  case object Conso  extends EmailCategory
+
+}
+
+trait EmailDefinition {
+  val category: EmailCategory
+  def examples: Seq[(String, EmailAddress => Email)]
+
+}

--- a/app/services/emails/EmailDefinitions.scala
+++ b/app/services/emails/EmailDefinitions.scala
@@ -3,6 +3,34 @@ package services.emails
 import enumeratum.EnumEntry
 import enumeratum.PlayEnum
 import play.api.i18n.MessagesApi
+import services.emails.EmailDefinitionsAdmin.AdminAccessLink
+import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
+import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotification
+import services.emails.EmailDefinitionsConsumer.ConsumerProResponseNotificationOnAdminCompletion
+import services.emails.EmailDefinitionsConsumer.ConsumerReportAcknowledgment
+import services.emails.EmailDefinitionsConsumer.ConsumerReportClosedNoAction
+import services.emails.EmailDefinitionsConsumer.ConsumerReportClosedNoReading
+import services.emails.EmailDefinitionsConsumer.ConsumerReportDeletionConfirmation
+import services.emails.EmailDefinitionsConsumer.ConsumerReportReadByProNotification
+import services.emails.EmailDefinitionsConsumer.ConsumerValidateEmail
+import services.emails.EmailDefinitionsDggcrf.DgccrfAgentAccessLink
+import services.emails.EmailDefinitionsDggcrf.DgccrfDangerousProductReportNotification
+import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
+import services.emails.EmailDefinitionsDggcrf.DgccrfReportNotification
+import services.emails.EmailDefinitionsDggcrf.DgccrfValidateEmail
+import services.emails.EmailDefinitionsPro.ProCompaniesAccessesInvitations
+import services.emails.EmailDefinitionsPro.ProCompanyAccessInvitation
+import services.emails.EmailDefinitionsPro.ProNewCompaniesAccesses
+import services.emails.EmailDefinitionsPro.ProNewCompanyAccess
+import services.emails.EmailDefinitionsPro.ProNewReportNotification
+import services.emails.EmailDefinitionsPro.ProReportAssignedNotification
+import services.emails.EmailDefinitionsPro.ProReportReOpeningNotification
+import services.emails.EmailDefinitionsPro.ProReportsReadReminder
+import services.emails.EmailDefinitionsPro.ProReportsUnreadReminder
+import services.emails.EmailDefinitionsPro.ProResponseAcknowledgment
+import services.emails.EmailDefinitionsPro.ProResponseAcknowledgmentOnAdminCompletion
+import services.emails.EmailDefinitionsVarious.ResetPassword
+import services.emails.EmailDefinitionsVarious.UpdateEmailAddress
 import utils.EmailAddress
 
 sealed trait EmailCategory extends EnumEntry
@@ -25,4 +53,42 @@ trait EmailDefinition {
 
   def examples: Seq[(String, (EmailAddress, MessagesApi) => Email)]
 
+}
+
+object EmailDefinitions {
+  val allEmailDefinitions: Seq[EmailDefinition] = Seq(
+    // Various
+    ResetPassword,
+    UpdateEmailAddress,
+    // Admin
+    AdminAccessLink,
+    AdminProbeTriggered,
+    // Dgccrf
+    DgccrfAgentAccessLink,
+    DgccrfInactiveAccount,
+    DgccrfDangerousProductReportNotification,
+    DgccrfReportNotification,
+    DgccrfValidateEmail,
+    // Pro
+    ProCompanyAccessInvitation,
+    ProCompaniesAccessesInvitations,
+    ProNewCompanyAccess,
+    ProNewCompaniesAccesses,
+    ProResponseAcknowledgment,
+    ProResponseAcknowledgmentOnAdminCompletion,
+    ProNewReportNotification,
+    ProReportReOpeningNotification,
+    ProReportsReadReminder,
+    ProReportsUnreadReminder,
+    ProReportAssignedNotification,
+    // Consumer
+    ConsumerReportDeletionConfirmation,
+    ConsumerReportAcknowledgment,
+    ConsumerReportReadByProNotification,
+    ConsumerProResponseNotification,
+    ConsumerProResponseNotificationOnAdminCompletion,
+    ConsumerReportClosedNoReading,
+    ConsumerReportClosedNoAction,
+    ConsumerValidateEmail
+  )
 }

--- a/app/services/emails/EmailDefinitions.scala
+++ b/app/services/emails/EmailDefinitions.scala
@@ -21,6 +21,7 @@ object EmailCategory extends PlayEnum[EmailCategory] {
 
 trait EmailDefinition {
   val category: EmailCategory
+
   def examples: Seq[(String, EmailAddress => Email)]
 
 }

--- a/app/services/emails/EmailDefinitions.scala
+++ b/app/services/emails/EmailDefinitions.scala
@@ -36,7 +36,10 @@ import utils.EmailAddress
 trait EmailDefinition {
   val category: EmailCategory
 
-  def examples: Seq[(String, (EmailAddress, MessagesApi) => Email)]
+  def examples: Seq[(String, (EmailAddress, MessagesApi) => BaseEmail)]
+
+  // Each EmailDefinition object should also define an Email case class
+  // This can't be enforced sadly
 
 }
 

--- a/app/services/emails/EmailDefinitionsAdmin.scala
+++ b/app/services/emails/EmailDefinitionsAdmin.scala
@@ -13,7 +13,7 @@ object EmailDefinitionsAdmin {
   case object AdminAccessLink extends EmailDefinition {
     override val category = Admin
 
-    final case class EmailImpl(recipient: EmailAddress, invitationUrl: URI) extends Email {
+    final case class Email(recipient: EmailAddress, invitationUrl: URI) extends BaseEmail {
       override val subject: String = EmailSubjects.ADMIN_ACCESS_LINK
       override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
         views.html.mails.admin.accessLink(invitationUrl).toString
@@ -21,14 +21,14 @@ object EmailDefinitionsAdmin {
       override val recipients: List[EmailAddress] = List(recipient)
     }
     override def examples =
-      Seq("access_link" -> ((recipient, _) => EmailImpl(recipient, dummyURL)))
+      Seq("access_link" -> ((recipient, _) => Email(recipient, dummyURL)))
 
   }
 
   case object AdminProbeTriggered extends EmailDefinition {
     override val category = Admin
-    final case class EmailImpl(recipients: Seq[EmailAddress], probeName: String, rate: Double, issue: String)
-        extends Email {
+    final case class Email(recipients: Seq[EmailAddress], probeName: String, rate: Double, issue: String)
+        extends BaseEmail {
       override val subject: String = EmailSubjects.ADMIN_PROBE_TRIGGERED
       override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
         views.html.mails.admin.probetriggered(probeName, rate, issue).toString()
@@ -36,7 +36,7 @@ object EmailDefinitionsAdmin {
     override def examples =
       Seq(
         "probe_triggered" -> ((recipient, _) =>
-          EmailImpl(Seq(recipient), "Taux de schtroumpfs pas assez schtroumpfés", 0.2, "bas")
+          Email(Seq(recipient), "Taux de schtroumpfs pas assez schtroumpfés", 0.2, "bas")
         )
       )
 

--- a/app/services/emails/EmailDefinitionsAdmin.scala
+++ b/app/services/emails/EmailDefinitionsAdmin.scala
@@ -13,38 +13,33 @@ object EmailDefinitionsAdmin {
   case object AdminAccessLink extends EmailDefinition {
     override val category = Admin
 
+    final case class EmailImpl(recipient: EmailAddress, invitationUrl: URI) extends Email {
+      override val subject: String = EmailSubjects.ADMIN_ACCESS_LINK
+      override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+        views.html.mails.admin.accessLink(invitationUrl).toString
+
+      override val recipients: List[EmailAddress] = List(recipient)
+    }
     override def examples =
-      Seq("access_link" -> ((recipient, _) => build(recipient, dummyURL)))
+      Seq("access_link" -> ((recipient, _) => EmailImpl(recipient, dummyURL)))
 
-    def build(recipient: EmailAddress, invitationUrl: URI): Email =
-      new Email {
-        override val subject: String = EmailSubjects.ADMIN_ACCESS_LINK
-
-        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-          views.html.mails.admin.accessLink(invitationUrl).toString
-
-        override val recipients: List[EmailAddress] = List(recipient)
-      }
   }
 
   case object AdminProbeTriggered extends EmailDefinition {
     override val category = Admin
-
+    final case class EmailImpl(recipients: Seq[EmailAddress], probeName: String, rate: Double, issue: String)
+        extends Email {
+      override val subject: String = EmailSubjects.ADMIN_PROBE_TRIGGERED
+      override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+        views.html.mails.admin.probetriggered(probeName, rate, issue).toString()
+    }
     override def examples =
       Seq(
         "probe_triggered" -> ((recipient, _) =>
-          build(Seq(recipient), "Taux de schtroumpfs pas assez schtroumpfés", 0.2, "bas")
+          EmailImpl(Seq(recipient), "Taux de schtroumpfs pas assez schtroumpfés", 0.2, "bas")
         )
       )
 
-    def build(theRecipients: Seq[EmailAddress], probeName: String, rate: Double, issue: String): Email =
-      new Email {
-        override val recipients      = theRecipients
-        override val subject: String = EmailSubjects.ADMIN_PROBE_TRIGGERED
-
-        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-          views.html.mails.admin.probetriggered(probeName, rate, issue).toString()
-      }
   }
 
 }

--- a/app/services/emails/EmailDefinitionsAdmin.scala
+++ b/app/services/emails/EmailDefinitionsAdmin.scala
@@ -14,7 +14,7 @@ object EmailDefinitionsAdmin {
     override val category = Admin
 
     override def examples =
-      Seq("access_link" -> (recipient => build(recipient, dummyURL)))
+      Seq("access_link" -> ((recipient, _) => build(recipient, dummyURL)))
 
     def build(recipient: EmailAddress, invitationUrl: URI): Email =
       new Email {
@@ -32,7 +32,7 @@ object EmailDefinitionsAdmin {
 
     override def examples =
       Seq(
-        "probe_triggered" -> (recipient =>
+        "probe_triggered" -> ((recipient, _) =>
           build(Seq(recipient), "Taux de schtroumpfs pas assez schtroumpfés", 0.2, "bas")
         )
       )

--- a/app/services/emails/EmailDefinitionsAdmin.scala
+++ b/app/services/emails/EmailDefinitionsAdmin.scala
@@ -1,0 +1,50 @@
+package services.emails
+
+import services.emails.EmailCategory.Admin
+import services.emails.EmailsExamplesUtils._
+import utils.EmailAddress
+import utils.EmailSubjects
+import utils.FrontRoute
+
+import java.net.URI
+
+object EmailDefinitionsAdmin {
+
+  case object AdminAccessLink extends EmailDefinition {
+    override val category = Admin
+
+    override def examples =
+      Seq("access_link" -> (recipient => build(recipient, dummyURL)))
+
+    def build(recipient: EmailAddress, invitationUrl: URI): Email =
+      new Email {
+        override val subject: String = EmailSubjects.ADMIN_ACCESS_LINK
+
+        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+          views.html.mails.admin.accessLink(invitationUrl).toString
+
+        override val recipients: List[EmailAddress] = List(recipient)
+      }
+  }
+
+  case object AdminProbeTriggered extends EmailDefinition {
+    override val category = Admin
+
+    override def examples =
+      Seq(
+        "probe_triggered" -> (recipient =>
+          build(Seq(recipient), "Taux de schtroumpfs pas assez schtroumpfés", 0.2, "bas")
+        )
+      )
+
+    def build(theRecipients: Seq[EmailAddress], probeName: String, rate: Double, issue: String): Email =
+      new Email {
+        override val recipients      = theRecipients
+        override val subject: String = EmailSubjects.ADMIN_PROBE_TRIGGERED
+
+        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+          views.html.mails.admin.probetriggered(probeName, rate, issue).toString()
+      }
+  }
+
+}

--- a/app/services/emails/EmailDefinitionsConsumer.scala
+++ b/app/services/emails/EmailDefinitionsConsumer.scala
@@ -4,11 +4,7 @@ import models.EmailValidation
 import models.company.Address
 import models.company.Company
 import models.event.Event
-import models.report.Report
-import models.report.ReportFile
-import models.report.ReportResponse
-import models.report.ReportStatus
-import models.report.ReportTag
+import models.report._
 import play.api.i18n.Lang
 import play.api.i18n.MessagesApi
 import play.api.i18n.MessagesImpl
@@ -232,7 +228,7 @@ object EmailDefinitionsConsumer {
         event: Event,
         files: Seq[ReportFile],
         messagesApi: MessagesApi
-    ) extends ConsumerEmail {
+    ) extends Email {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -263,7 +259,7 @@ object EmailDefinitionsConsumer {
         report: Report,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends ConsumerEmail {
+    ) extends Email {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -293,7 +289,7 @@ object EmailDefinitionsConsumer {
         reportResponse: ReportResponse,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends ConsumerEmail {
+    ) extends Email {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -329,7 +325,7 @@ object EmailDefinitionsConsumer {
         report: Report,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends ConsumerEmail {
+    ) extends Email {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -409,7 +405,7 @@ object EmailDefinitionsConsumer {
         report: Report,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends ConsumerEmail {
+    ) extends Email {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -439,7 +435,7 @@ object EmailDefinitionsConsumer {
         emailValidation: EmailValidation,
         locale: Option[Locale],
         messagesApi: MessagesApi
-    ) extends ConsumerEmail {
+    ) extends Email {
       private val lang                                        = Lang(getLocaleOrDefault(locale))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 

--- a/app/services/emails/EmailDefinitionsConsumer.scala
+++ b/app/services/emails/EmailDefinitionsConsumer.scala
@@ -247,6 +247,35 @@ object EmailDefinitionsConsumer {
     }
   }
 
+  case object ConsumerReportReadByProNotification extends EmailDefinition {
+    override val category = Consumer
+
+    override def examples =
+      Seq(
+        "report_transmitted" -> ((recipient, messagesApi) =>
+          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+        )
+      )
+
+    final case class EmailImpl(
+        report: Report,
+        maybeCompany: Option[Company],
+        messagesApi: MessagesApi
+    ) extends ConsumerEmail {
+      private val lang                                        = Lang(getLocaleOrDefault(report.lang))
+      implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
+
+      override val recipients: List[EmailAddress] = List(report.email)
+      override val subject: String                = messagesApi("ConsumerReportTransmittedEmail.subject")(lang)
+
+      override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+        views.html.mails.consumer.reportTransmission(report, maybeCompany).toString
+
+      override def getAttachements: AttachmentService => Seq[Attachment] =
+        _.attachmentSeqForWorkflowStepN(3, report.lang.getOrElse(Locale.FRENCH))
+    }
+  }
+
   private def getLocaleOrDefault(locale: Option[Locale]): Locale = locale.getOrElse(Locale.FRENCH)
 
 }

--- a/app/services/emails/EmailDefinitionsConsumer.scala
+++ b/app/services/emails/EmailDefinitionsConsumer.scala
@@ -1,0 +1,43 @@
+package services.emails
+
+import models.company.Company
+import models.report.Report
+import play.api.i18n.Lang
+import play.api.i18n.MessagesApi
+import play.api.i18n.MessagesImpl
+import play.api.i18n.MessagesProvider
+import services.emails.EmailCategory.Consumer
+import services.emails.EmailsExamplesUtils._
+import utils.EmailAddress
+import utils.FrontRoute
+
+import java.util.Locale
+
+object EmailDefinitionsConsumer {
+
+  case object ConsumerReportDeletionConfirmation extends EmailDefinition {
+    override val category = Consumer
+
+    override def examples =
+      Seq(
+        "report_deletion_confirmation" -> ((recipient, messagesApi) =>
+          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+        )
+      )
+
+    final case class EmailImpl(report: Report, maybeCompany: Option[Company], messagesApi: MessagesApi) extends Email {
+      private val lang                                        = Lang(getLocaleOrDefault(report.lang))
+      implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
+      override val recipients: List[EmailAddress]             = List(report.email)
+      override val subject: String                            = messagesApi("ConsumerReportDeletionEmail.subject")(lang)
+
+      override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
+        views.html.mails.consumer
+          .confirmReportDeletionEmail(report, maybeCompany)(frontRoute, messagesProvider)
+          .toString
+    }
+  }
+
+  private def getLocaleOrDefault(locale: Option[Locale]): Locale = locale.getOrElse(Locale.FRENCH)
+
+}

--- a/app/services/emails/EmailDefinitionsConsumer.scala
+++ b/app/services/emails/EmailDefinitionsConsumer.scala
@@ -387,6 +387,44 @@ object EmailDefinitionsConsumer {
 
   }
 
+  case object ConsumerReportClosedNoAction extends EmailDefinition {
+    override val category = Consumer
+
+    override def examples =
+      Seq(
+        "report_closed_no_action" -> ((recipient, messagesApi) =>
+          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+        ),
+        "report_closed_no_action_case_dispute" -> ((recipient, messagesApi) =>
+          EmailImpl(
+            genReport.copy(email = recipient, tags = List(ReportTag.LitigeContractuel)),
+            Some(genCompany),
+            messagesApi
+          )
+        )
+      )
+
+    final case class EmailImpl(
+        report: Report,
+        maybeCompany: Option[Company],
+        messagesApi: MessagesApi
+    ) extends ConsumerEmail {
+      private val lang                                        = Lang(getLocaleOrDefault(report.lang))
+      implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
+
+      override val recipients: List[EmailAddress] = List(report.email)
+      override val subject: String                = messagesApi("ReportNotAnswered.subject")(lang)
+
+      override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
+        views.html.mails.consumer.reportClosedByNoAction(report, maybeCompany)(frontRoute, messagesProvider).toString
+
+      override def getAttachements: AttachmentService => Seq[Attachment] =
+        _.needWorkflowSeqForWorkflowStepN(4, report)
+
+    }
+
+  }
+
   private def getLocaleOrDefault(locale: Option[Locale]): Locale = locale.getOrElse(Locale.FRENCH)
 
 }

--- a/app/services/emails/EmailDefinitionsConsumer.scala
+++ b/app/services/emails/EmailDefinitionsConsumer.scala
@@ -1,13 +1,21 @@
 package services.emails
 
+import models.company.Address
 import models.company.Company
+import models.event.Event
 import models.report.Report
+import models.report.ReportFile
+import models.report.ReportStatus
+import models.report.ReportTag
 import play.api.i18n.Lang
 import play.api.i18n.MessagesApi
 import play.api.i18n.MessagesImpl
 import play.api.i18n.MessagesProvider
+import play.api.libs.mailer.Attachment
+import services.AttachmentService
 import services.emails.EmailCategory.Consumer
 import services.emails.EmailsExamplesUtils._
+import utils.Country
 import utils.EmailAddress
 import utils.FrontRoute
 
@@ -35,6 +43,207 @@ object EmailDefinitionsConsumer {
         views.html.mails.consumer
           .confirmReportDeletionEmail(report, maybeCompany)(frontRoute, messagesProvider)
           .toString
+    }
+  }
+
+  case object ConsumerReportAcknowledgment extends EmailDefinition {
+    override val category = Consumer
+
+    override def examples =
+      Seq(
+        "report_ack" -> ((recipient, messagesApi) =>
+          EmailImpl(
+            genReport.copy(email = recipient),
+            Some(genCompany),
+            genEvent,
+            Nil,
+            messagesApi
+          )
+        ),
+        "report_ack_case_reponseconso" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(status = ReportStatus.NA, tags = List(ReportTag.ReponseConso), email = recipient),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_dispute" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(tags = List(ReportTag.LitigeContractuel), email = recipient),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_dangerous_product" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.TraitementEnCours,
+                tags = List(ReportTag.ProduitDangereux),
+                email = recipient
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_euro" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.NA,
+                companyAddress = Address(country = Some(Country.Italie)),
+                email = recipient
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_euro_and_dispute" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.NA,
+                tags = List(ReportTag.LitigeContractuel),
+                companyAddress = Address(country = Some(Country.Islande)),
+                email = recipient
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_andorre" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.NA,
+                companyAddress = Address(country = Some(Country.Andorre)),
+                email = recipient
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_andorre_and_dispute" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.NA,
+                tags = List(ReportTag.LitigeContractuel),
+                companyAddress = Address(country = Some(Country.Andorre)),
+                email = recipient
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_suisse" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.NA,
+                companyAddress = Address(country = Some(Country.Suisse)),
+                email = recipient
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_suisse_and_dispute" -> ((recipient, messagesApi) =>
+          EmailImpl(
+            genReport.copy(
+              status = ReportStatus.NA,
+              tags = List(ReportTag.LitigeContractuel),
+              companyAddress = Address(country = Some(Country.Suisse)),
+              email = recipient
+            ),
+            Some(genCompany),
+            genEvent,
+            Nil,
+            messagesApi
+          )
+        ),
+        "report_ack_case_compagnie_aerienne" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.NA,
+                email = recipient,
+                tags = List(ReportTag.CompagnieAerienne)
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_abroad_default" ->
+          ((recipient, messagesApi) =>
+            EmailImpl(
+              genReport.copy(
+                status = ReportStatus.NA,
+                companyAddress = Address(country = Some(Country.Bahamas)),
+                email = recipient
+              ),
+              Some(genCompany),
+              genEvent,
+              Nil,
+              messagesApi
+            )
+          ),
+        "report_ack_case_abroad_default_and_dispute" -> ((recipient, messagesApi) =>
+          EmailImpl(
+            genReport.copy(
+              status = ReportStatus.NA,
+              tags = List(ReportTag.LitigeContractuel),
+              companyAddress = Address(country = Some(Country.Bahamas)),
+              email = recipient
+            ),
+            Some(genCompany),
+            genEvent,
+            Nil,
+            messagesApi
+          )
+        )
+      )
+
+    final case class EmailImpl(
+        report: Report,
+        maybeCompany: Option[Company],
+        event: Event,
+        files: Seq[ReportFile],
+        messagesApi: MessagesApi
+    ) extends ConsumerEmail {
+      private val lang                                        = Lang(getLocaleOrDefault(report.lang))
+      implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
+
+      override val recipients: List[EmailAddress] = List(report.email)
+      override val subject: String                = messagesApi("ReportAckEmail.subject")(lang)
+
+      override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
+        views.html.mails.consumer
+          .reportAcknowledgment(report, maybeCompany, files.toList)(frontRoute, messagesProvider)
+          .toString
+
+      override def getAttachements: AttachmentService => Seq[Attachment] =
+        _.reportAcknowledgmentAttachement(report, maybeCompany, event, files, messagesProvider)
     }
   }
 

--- a/app/services/emails/EmailDefinitionsConsumer.scala
+++ b/app/services/emails/EmailDefinitionsConsumer.scala
@@ -27,11 +27,11 @@ object EmailDefinitionsConsumer {
     override def examples =
       Seq(
         "report_deletion_confirmation" -> ((recipient, messagesApi) =>
-          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+          Email(genReport.copy(email = recipient), Some(genCompany), messagesApi)
         )
       )
 
-    final case class EmailImpl(report: Report, maybeCompany: Option[Company], messagesApi: MessagesApi) extends Email {
+    final case class Email(report: Report, maybeCompany: Option[Company], messagesApi: MessagesApi) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
       override val recipients: List[EmailAddress]             = List(report.email)
@@ -50,7 +50,7 @@ object EmailDefinitionsConsumer {
     override def examples =
       Seq(
         "report_ack" -> ((recipient, messagesApi) =>
-          EmailImpl(
+          Email(
             genReport.copy(email = recipient),
             Some(genCompany),
             genEvent,
@@ -60,7 +60,7 @@ object EmailDefinitionsConsumer {
         ),
         "report_ack_case_reponseconso" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(status = ReportStatus.NA, tags = List(ReportTag.ReponseConso), email = recipient),
               Some(genCompany),
               genEvent,
@@ -70,7 +70,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_dispute" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(tags = List(ReportTag.LitigeContractuel), email = recipient),
               Some(genCompany),
               genEvent,
@@ -80,7 +80,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_dangerous_product" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.TraitementEnCours,
                 tags = List(ReportTag.ProduitDangereux),
@@ -94,7 +94,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_euro" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.NA,
                 companyAddress = Address(country = Some(Country.Italie)),
@@ -108,7 +108,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_euro_and_dispute" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.NA,
                 tags = List(ReportTag.LitigeContractuel),
@@ -123,7 +123,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_andorre" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.NA,
                 companyAddress = Address(country = Some(Country.Andorre)),
@@ -137,7 +137,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_andorre_and_dispute" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.NA,
                 tags = List(ReportTag.LitigeContractuel),
@@ -152,7 +152,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_suisse" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.NA,
                 companyAddress = Address(country = Some(Country.Suisse)),
@@ -165,7 +165,7 @@ object EmailDefinitionsConsumer {
             )
           ),
         "report_ack_case_suisse_and_dispute" -> ((recipient, messagesApi) =>
-          EmailImpl(
+          Email(
             genReport.copy(
               status = ReportStatus.NA,
               tags = List(ReportTag.LitigeContractuel),
@@ -180,7 +180,7 @@ object EmailDefinitionsConsumer {
         ),
         "report_ack_case_compagnie_aerienne" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.NA,
                 email = recipient,
@@ -194,7 +194,7 @@ object EmailDefinitionsConsumer {
           ),
         "report_ack_case_abroad_default" ->
           ((recipient, messagesApi) =>
-            EmailImpl(
+            Email(
               genReport.copy(
                 status = ReportStatus.NA,
                 companyAddress = Address(country = Some(Country.Bahamas)),
@@ -207,7 +207,7 @@ object EmailDefinitionsConsumer {
             )
           ),
         "report_ack_case_abroad_default_and_dispute" -> ((recipient, messagesApi) =>
-          EmailImpl(
+          Email(
             genReport.copy(
               status = ReportStatus.NA,
               tags = List(ReportTag.LitigeContractuel),
@@ -222,13 +222,13 @@ object EmailDefinitionsConsumer {
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         report: Report,
         maybeCompany: Option[Company],
         event: Event,
         files: Seq[ReportFile],
         messagesApi: MessagesApi
-    ) extends Email {
+    ) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -251,15 +251,15 @@ object EmailDefinitionsConsumer {
     override def examples =
       Seq(
         "report_transmitted" -> ((recipient, messagesApi) =>
-          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+          Email(genReport.copy(email = recipient), Some(genCompany), messagesApi)
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         report: Report,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends Email {
+    ) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -280,16 +280,16 @@ object EmailDefinitionsConsumer {
     override def examples =
       Seq(
         "report_ack_pro_consumer" -> ((recipient, messagesApi) =>
-          EmailImpl(genReport.copy(email = recipient), genReportResponse, Some(genCompany), messagesApi)
+          Email(genReport.copy(email = recipient), genReportResponse, Some(genCompany), messagesApi)
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         report: Report,
         reportResponse: ReportResponse,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends Email {
+    ) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -317,15 +317,15 @@ object EmailDefinitionsConsumer {
     override def examples =
       Seq(
         "report_ack_pro_consumer_on_admin_completion" -> ((recipient, messagesApi) =>
-          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+          Email(genReport.copy(email = recipient), Some(genCompany), messagesApi)
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         report: Report,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends Email {
+    ) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -352,10 +352,10 @@ object EmailDefinitionsConsumer {
     override def examples =
       Seq(
         "report_closed_no_reading" -> ((recipient, messagesApi) =>
-          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+          Email(genReport.copy(email = recipient), Some(genCompany), messagesApi)
         ),
         "report_closed_no_reading_case_dispute" -> ((recipient, messagesApi) =>
-          EmailImpl(
+          Email(
             genReport.copy(email = recipient, tags = List(ReportTag.LitigeContractuel)),
             Some(genCompany),
             messagesApi
@@ -363,11 +363,11 @@ object EmailDefinitionsConsumer {
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         report: Report,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends Email {
+    ) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -390,10 +390,10 @@ object EmailDefinitionsConsumer {
     override def examples =
       Seq(
         "report_closed_no_action" -> ((recipient, messagesApi) =>
-          EmailImpl(genReport.copy(email = recipient), Some(genCompany), messagesApi)
+          Email(genReport.copy(email = recipient), Some(genCompany), messagesApi)
         ),
         "report_closed_no_action_case_dispute" -> ((recipient, messagesApi) =>
-          EmailImpl(
+          Email(
             genReport.copy(email = recipient, tags = List(ReportTag.LitigeContractuel)),
             Some(genCompany),
             messagesApi
@@ -401,11 +401,11 @@ object EmailDefinitionsConsumer {
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         report: Report,
         maybeCompany: Option[Company],
         messagesApi: MessagesApi
-    ) extends Email {
+    ) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(report.lang))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 
@@ -426,16 +426,14 @@ object EmailDefinitionsConsumer {
 
     override def examples =
       Seq(
-        "validate_email" -> ((recipient, messagesApi) =>
-          EmailImpl(EmailValidation(email = recipient), None, messagesApi)
-        )
+        "validate_email" -> ((recipient, messagesApi) => Email(EmailValidation(email = recipient), None, messagesApi))
       )
 
-    final case class EmailImpl(
+    final case class Email(
         emailValidation: EmailValidation,
         locale: Option[Locale],
         messagesApi: MessagesApi
-    ) extends Email {
+    ) extends BaseEmail {
       private val lang                                        = Lang(getLocaleOrDefault(locale))
       implicit private val messagesProvider: MessagesProvider = MessagesImpl(lang, messagesApi)
 

--- a/app/services/emails/EmailDefinitionsDggcrf.scala
+++ b/app/services/emails/EmailDefinitionsDggcrf.scala
@@ -1,6 +1,7 @@
 package services.emails
 
 import models.User
+import models.report.Report
 import services.emails.EmailCategory.Dgccrf
 import services.emails.EmailsExamplesUtils._
 import utils.EmailAddress
@@ -43,6 +44,24 @@ object EmailDefinitionsDggcrf {
         override val subject: String               = EmailSubjects.INACTIVE_DGCCRF_ACCOUNT_REMINDER
         override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
           views.html.mails.dgccrf.inactiveAccount(user.fullName, expirationDate)(frontRoute).toString
+      }
+  }
+
+  case object DgccrfDangerousProductReportNotification extends EmailDefinition {
+    override val category = Dgccrf
+
+    override def examples =
+      Seq(
+        "report_dangerous_product_notification" -> (recipient => build(Seq(recipient), genReport))
+      )
+
+    def build(theRecipients: Seq[EmailAddress], report: Report): Email =
+      new Email {
+        override val recipients = theRecipients
+        override val subject    = EmailSubjects.REPORT_NOTIF_DGCCRF(1, Some("[Produits dangereux] "))
+
+        override def getBody = (frontRoute, contact) =>
+          views.html.mails.dgccrf.reportDangerousProductNotification(report)(frontRoute, contact).toString
       }
   }
 

--- a/app/services/emails/EmailDefinitionsDggcrf.scala
+++ b/app/services/emails/EmailDefinitionsDggcrf.scala
@@ -104,4 +104,32 @@ object EmailDefinitionsDggcrf {
       }
   }
 
+  case object DgccrfValidateEmail extends EmailDefinition {
+    override val category = Dgccrf
+
+    override def examples =
+      Seq(
+        "validate_email" -> (recipient =>
+          build(
+            recipient,
+            7,
+            dummyURL
+          )
+        )
+      )
+
+    def build(
+        email: EmailAddress,
+        daysBeforeExpiry: Int,
+        validationUrl: URI
+    ): Email =
+      new Email {
+        override val recipients: List[EmailAddress] = List(email)
+        override val subject: String                = EmailSubjects.VALIDATE_EMAIL
+
+        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+          views.html.mails.validateEmail(validationUrl, daysBeforeExpiry).toString
+      }
+  }
+
 }

--- a/app/services/emails/EmailDefinitionsDggcrf.scala
+++ b/app/services/emails/EmailDefinitionsDggcrf.scala
@@ -1,5 +1,6 @@
 package services.emails
 
+import models.User
 import services.emails.EmailCategory.Dgccrf
 import services.emails.EmailsExamplesUtils._
 import utils.EmailAddress
@@ -7,6 +8,7 @@ import utils.EmailSubjects
 import utils.FrontRoute
 
 import java.net.URI
+import java.time.LocalDate
 
 object EmailDefinitionsDggcrf {
 
@@ -22,6 +24,25 @@ object EmailDefinitionsDggcrf {
         override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
           views.html.mails.dgccrf.accessLink(invitationUrl, role).toString
         override val recipients: List[EmailAddress] = List(recipient)
+      }
+  }
+
+  case object DgccrfInactiveAccount extends EmailDefinition {
+    override val category = Dgccrf
+
+    override def examples =
+      Seq(
+        "inactive_account_reminder" -> (recipient =>
+          build(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
+        )
+      )
+
+    def build(user: User, expirationDate: Option[LocalDate]): Email =
+      new Email {
+        override val recipients: Seq[EmailAddress] = List(user.email)
+        override val subject: String               = EmailSubjects.INACTIVE_DGCCRF_ACCOUNT_REMINDER
+        override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
+          views.html.mails.dgccrf.inactiveAccount(user.fullName, expirationDate)(frontRoute).toString
       }
   }
 

--- a/app/services/emails/EmailDefinitionsDggcrf.scala
+++ b/app/services/emails/EmailDefinitionsDggcrf.scala
@@ -1,0 +1,28 @@
+package services.emails
+
+import services.emails.EmailCategory.Dgccrf
+import services.emails.EmailsExamplesUtils._
+import utils.EmailAddress
+import utils.EmailSubjects
+import utils.FrontRoute
+
+import java.net.URI
+
+object EmailDefinitionsDggcrf {
+
+  case object DgccrfAgentAccessLink extends EmailDefinition {
+    override val category = Dgccrf
+
+    override def examples =
+      Seq("access_link" -> (recipient => build("DGCCRF")(recipient, dummyURL)))
+
+    def build(role: String)(recipient: EmailAddress, invitationUrl: URI): Email =
+      new Email {
+        override val subject: String = EmailSubjects.DGCCRF_ACCESS_LINK
+        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+          views.html.mails.dgccrf.accessLink(invitationUrl, role).toString
+        override val recipients: List[EmailAddress] = List(recipient)
+      }
+  }
+
+}

--- a/app/services/emails/EmailDefinitionsDggcrf.scala
+++ b/app/services/emails/EmailDefinitionsDggcrf.scala
@@ -20,15 +20,17 @@ object EmailDefinitionsDggcrf {
     override val category = Dgccrf
 
     override def examples =
-      Seq("access_link" -> ((recipient, _) => build("DGCCRF")(recipient, dummyURL)))
+      Seq("access_link" -> ((recipient, _) => EmailImpl("DGCCRF")(recipient, dummyURL)))
 
-    def build(role: String)(recipient: EmailAddress, invitationUrl: URI): Email =
-      new Email {
-        override val subject: String = EmailSubjects.DGCCRF_ACCESS_LINK
-        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-          views.html.mails.dgccrf.accessLink(invitationUrl, role).toString
-        override val recipients: List[EmailAddress] = List(recipient)
-      }
+    final case class EmailImpl(role: String)(recipient: EmailAddress, invitationUrl: URI) extends Email {
+      override val subject: String = EmailSubjects.DGCCRF_ACCESS_LINK
+
+      override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+        views.html.mails.dgccrf.accessLink(invitationUrl, role).toString
+
+      override val recipients: List[EmailAddress] = List(recipient)
+    }
+
   }
 
   case object DgccrfInactiveAccount extends EmailDefinition {
@@ -37,17 +39,20 @@ object EmailDefinitionsDggcrf {
     override def examples =
       Seq(
         "inactive_account_reminder" -> ((recipient, _) =>
-          build(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
+          EmailImpl(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
         )
       )
 
-    def build(user: User, expirationDate: Option[LocalDate]): Email =
-      new Email {
-        override val recipients: Seq[EmailAddress] = List(user.email)
-        override val subject: String               = EmailSubjects.INACTIVE_DGCCRF_ACCOUNT_REMINDER
-        override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
-          views.html.mails.dgccrf.inactiveAccount(user.fullName, expirationDate)(frontRoute).toString
-      }
+    final case class EmailImpl(
+        user: User,
+        expirationDate: Option[LocalDate]
+    ) extends Email {
+      override val recipients: Seq[EmailAddress] = List(user.email)
+      override val subject: String               = EmailSubjects.INACTIVE_DGCCRF_ACCOUNT_REMINDER
+
+      override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, _) =>
+        views.html.mails.dgccrf.inactiveAccount(user.fullName, expirationDate)(frontRoute).toString
+    }
   }
 
   case object DgccrfDangerousProductReportNotification extends EmailDefinition {
@@ -55,17 +60,18 @@ object EmailDefinitionsDggcrf {
 
     override def examples =
       Seq(
-        "report_dangerous_product_notification" -> ((recipient, _) => build(Seq(recipient), genReport))
+        "report_dangerous_product_notification" -> ((recipient, _) => EmailImpl(Seq(recipient), genReport))
       )
 
-    def build(theRecipients: Seq[EmailAddress], report: Report): Email =
-      new Email {
-        override val recipients = theRecipients
-        override val subject    = EmailSubjects.REPORT_NOTIF_DGCCRF(1, Some("[Produits dangereux] "))
+    final case class EmailImpl(
+        recipients: Seq[EmailAddress],
+        report: Report
+    ) extends Email {
+      override val subject: String = EmailSubjects.REPORT_NOTIF_DGCCRF(1, Some("[Produits dangereux] "))
 
-        override def getBody = (frontRoute, contact) =>
-          views.html.mails.dgccrf.reportDangerousProductNotification(report)(frontRoute, contact).toString
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contact) =>
+        views.html.mails.dgccrf.reportDangerousProductNotification(report)(frontRoute, contact).toString
+    }
   }
 
   case object DgccrfReportNotification extends EmailDefinition {

--- a/app/services/emails/EmailDefinitionsDggcrf.scala
+++ b/app/services/emails/EmailDefinitionsDggcrf.scala
@@ -20,7 +20,7 @@ object EmailDefinitionsDggcrf {
     override val category = Dgccrf
 
     override def examples =
-      Seq("access_link" -> (recipient => build("DGCCRF")(recipient, dummyURL)))
+      Seq("access_link" -> ((recipient, _) => build("DGCCRF")(recipient, dummyURL)))
 
     def build(role: String)(recipient: EmailAddress, invitationUrl: URI): Email =
       new Email {
@@ -36,7 +36,7 @@ object EmailDefinitionsDggcrf {
 
     override def examples =
       Seq(
-        "inactive_account_reminder" -> (recipient =>
+        "inactive_account_reminder" -> ((recipient, _) =>
           build(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
         )
       )
@@ -55,7 +55,7 @@ object EmailDefinitionsDggcrf {
 
     override def examples =
       Seq(
-        "report_dangerous_product_notification" -> (recipient => build(Seq(recipient), genReport))
+        "report_dangerous_product_notification" -> ((recipient, _) => build(Seq(recipient), genReport))
       )
 
     def build(theRecipients: Seq[EmailAddress], report: Report): Email =
@@ -73,7 +73,7 @@ object EmailDefinitionsDggcrf {
 
     override def examples =
       Seq(
-        "report_notif_dgccrf" -> (recipient =>
+        "report_notif_dgccrf" -> ((recipient, _) =>
           build(
             List(recipient),
             genSubscription,
@@ -109,7 +109,7 @@ object EmailDefinitionsDggcrf {
 
     override def examples =
       Seq(
-        "validate_email" -> (recipient =>
+        "validate_email" -> ((recipient, _) =>
           build(
             recipient,
             7,

--- a/app/services/emails/EmailDefinitionsDggcrf.scala
+++ b/app/services/emails/EmailDefinitionsDggcrf.scala
@@ -20,9 +20,9 @@ object EmailDefinitionsDggcrf {
     override val category = Dgccrf
 
     override def examples =
-      Seq("access_link" -> ((recipient, _) => EmailImpl("DGCCRF")(recipient, dummyURL)))
+      Seq("access_link" -> ((recipient, _) => Email("DGCCRF")(recipient, dummyURL)))
 
-    final case class EmailImpl(role: String)(recipient: EmailAddress, invitationUrl: URI) extends Email {
+    final case class Email(role: String)(recipient: EmailAddress, invitationUrl: URI) extends BaseEmail {
       override val subject: String = EmailSubjects.DGCCRF_ACCESS_LINK
 
       override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
@@ -39,14 +39,14 @@ object EmailDefinitionsDggcrf {
     override def examples =
       Seq(
         "inactive_account_reminder" -> ((recipient, _) =>
-          EmailImpl(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
+          Email(genUser.copy(email = recipient), Some(LocalDate.now().plusDays(90)))
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         user: User,
         expirationDate: Option[LocalDate]
-    ) extends Email {
+    ) extends BaseEmail {
       override val recipients: Seq[EmailAddress] = List(user.email)
       override val subject: String               = EmailSubjects.INACTIVE_DGCCRF_ACCOUNT_REMINDER
 
@@ -60,13 +60,13 @@ object EmailDefinitionsDggcrf {
 
     override def examples =
       Seq(
-        "report_dangerous_product_notification" -> ((recipient, _) => EmailImpl(Seq(recipient), genReport))
+        "report_dangerous_product_notification" -> ((recipient, _) => Email(Seq(recipient), genReport))
       )
 
-    final case class EmailImpl(
+    final case class Email(
         recipients: Seq[EmailAddress],
         report: Report
-    ) extends Email {
+    ) extends BaseEmail {
       override val subject: String = EmailSubjects.REPORT_NOTIF_DGCCRF(1, Some("[Produits dangereux] "))
 
       override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contact) =>
@@ -80,7 +80,7 @@ object EmailDefinitionsDggcrf {
     override def examples =
       Seq(
         "report_notif_dgccrf" -> ((recipient, _) =>
-          EmailImpl(
+          Email(
             List(recipient),
             genSubscription,
             List(
@@ -92,12 +92,12 @@ object EmailDefinitionsDggcrf {
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         recipients: List[EmailAddress],
         subscription: Subscription,
         reports: Seq[(Report, List[ReportFile])],
         startDate: LocalDate
-    ) extends Email {
+    ) extends BaseEmail {
       override val subject: String = EmailSubjects.REPORT_NOTIF_DGCCRF(
         reports.length,
         subscription.withTags.find(_ == ReportTag.ProduitDangereux).map(_ => "[Produits dangereux] ")
@@ -115,7 +115,7 @@ object EmailDefinitionsDggcrf {
     override def examples =
       Seq(
         "validate_email" -> ((recipient, _) =>
-          EmailImpl(
+          Email(
             recipient,
             7,
             dummyURL
@@ -123,7 +123,7 @@ object EmailDefinitionsDggcrf {
         )
       )
 
-    final case class EmailImpl(email: EmailAddress, daysBeforeExpiry: Int, validationUrl: URI) extends Email {
+    final case class Email(email: EmailAddress, daysBeforeExpiry: Int, validationUrl: URI) extends BaseEmail {
       override val recipients: List[EmailAddress] = List(email)
       override val subject: String                = EmailSubjects.VALIDATE_EMAIL
 

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -223,4 +223,25 @@ object EmailDefinitionsPro {
     }
   }
 
+  case object ProReportAssignedNotification extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq(
+        "report_assignement_to_other" -> (recipient =>
+          EmailImpl(report = genReport, assigningUser = genUser, assignedUser = genUser.copy(email = recipient))
+        )
+      )
+
+    final case class EmailImpl(report: Report, assigningUser: User, assignedUser: User)
+        extends ProFilteredEmailSingleReport {
+      override val recipients: List[EmailAddress] = List(assignedUser.email)
+      override val subject: String                = EmailSubjects.REPORT_ASSIGNED
+
+      override def getBody: (FrontRoute, EmailAddress) => String = { (frontRoute, _) =>
+        views.html.mails.professional.reportAssigned(report, assigningUser, assignedUser)(frontRoute).toString
+      }
+    }
+  }
+
 }

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -22,16 +22,21 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("access_invitation" -> ((recipient, _) => build(recipient, genCompany, dummyURL, None)))
+      Seq("access_invitation" -> ((recipient, _) => EmailImpl(recipient, genCompany, dummyURL, None)))
 
-    def build(recipient: EmailAddress, company: Company, invitationUrl: URI, invitedBy: Option[User]): Email =
-      new Email {
-        override val recipients: List[EmailAddress] = List(recipient)
-        override val subject: String                = EmailSubjects.COMPANY_ACCESS_INVITATION(company.name)
+    final case class EmailImpl(
+        recipient: EmailAddress,
+        company: Company,
+        invitationUrl: URI,
+        invitedBy: Option[User]
+    ) extends Email {
+      override val recipients: List[EmailAddress] = List(recipient)
+      override val subject: String                = EmailSubjects.COMPANY_ACCESS_INVITATION(company.name)
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (_, _) => views.html.mails.professional.companyAccessInvitation(invitationUrl, company, invitedBy).toString
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (_, _) => views.html.mails.professional.companyAccessInvitation(invitationUrl, company, invitedBy).toString
+    }
+
   }
 
   case object ProCompaniesAccessesInvitations extends EmailDefinition {
@@ -40,57 +45,67 @@ object EmailDefinitionsPro {
     override def examples =
       Seq(
         "access_invitation_multiple_companies" -> ((recipient, _) =>
-          build(recipient, genCompanyList, genSiren, dummyURL)
+          EmailImpl(recipient, genCompanyList, genSiren, dummyURL)
         )
       )
 
-    def build(recipient: EmailAddress, companies: List[Company], siren: SIREN, invitationUrl: URI): Email =
-      new Email {
-        override val recipients: List[EmailAddress] = List(recipient)
-        override val subject: String                = EmailSubjects.PRO_COMPANIES_ACCESSES_INVITATIONS(siren)
+    final case class EmailImpl(
+        recipient: EmailAddress,
+        companies: List[Company],
+        siren: SIREN,
+        invitationUrl: URI
+    ) extends Email {
+      override val recipients: List[EmailAddress] = List(recipient)
+      override val subject: String                = EmailSubjects.PRO_COMPANIES_ACCESSES_INVITATIONS(siren)
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (_, _) =>
-            views.html.mails.professional.companiesAccessesInvitations(invitationUrl, companies, siren.value).toString
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (_, _) =>
+          views.html.mails.professional.companiesAccessesInvitations(invitationUrl, companies, siren.value).toString
+    }
   }
 
   case object ProNewCompanyAccess extends EmailDefinition {
     override val category = Pro
 
     override def examples =
-      Seq("new_company_access" -> ((recipient, _) => build(recipient, genCompany, None)))
+      Seq("new_company_access" -> ((recipient, _) => EmailImpl(recipient, genCompany, None)))
 
-    def build(recipient: EmailAddress, company: Company, invitedBy: Option[User]): Email =
-      new Email {
-        override val recipients: List[EmailAddress] = List(recipient)
-        override val subject: String                = EmailSubjects.NEW_COMPANY_ACCESS(company.name)
+    final case class EmailImpl(
+        recipient: EmailAddress,
+        company: Company,
+        invitedBy: Option[User]
+    ) extends Email {
+      override val recipients: List[EmailAddress] = List(recipient)
+      override val subject: String                = EmailSubjects.NEW_COMPANY_ACCESS(company.name)
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (frontRoute, _) =>
-            views.html.mails.professional
-              .newCompanyAccessNotification(frontRoute.dashboard.login, company, invitedBy)(frontRoute)
-              .toString
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) =>
+          views.html.mails.professional
+            .newCompanyAccessNotification(frontRoute.dashboard.login, company, invitedBy)(frontRoute)
+            .toString
+    }
   }
 
   case object ProNewCompaniesAccesses extends EmailDefinition {
     override val category = Pro
 
     override def examples =
-      Seq("new_companies_accesses" -> ((recipient, _) => build(recipient, genCompanyList, genSiren)))
+      Seq("new_companies_accesses" -> ((recipient, _) => EmailImpl(recipient, genCompanyList, genSiren)))
 
-    def build(recipient: EmailAddress, companies: List[Company], siren: SIREN): Email =
-      new Email {
-        override val recipients: List[EmailAddress] = List(recipient)
-        override val subject: String                = EmailSubjects.PRO_NEW_COMPANIES_ACCESSES(siren)
+    final case class EmailImpl(
+        recipient: EmailAddress,
+        companies: List[Company],
+        siren: SIREN
+    ) extends Email {
+      override val recipients: List[EmailAddress] = List(recipient)
+      override val subject: String                = EmailSubjects.PRO_NEW_COMPANIES_ACCESSES(siren)
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (frontRoute, _) =>
-            views.html.mails.professional
-              .newCompaniesAccessesNotification(frontRoute.dashboard.login, companies, siren.value)(frontRoute)
-              .toString
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) =>
+          views.html.mails.professional
+            .newCompaniesAccessesNotification(frontRoute.dashboard.login, companies, siren.value)(frontRoute)
+            .toString
+    }
   }
 
   case object ProResponseAcknowledgment extends EmailDefinition {
@@ -98,20 +113,18 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_ack_pro" -> ((recipient, _) => build(genReport, genReportResponse, genUser.copy(email = recipient)))
+        "report_ack_pro" -> ((recipient, _) => EmailImpl(genReport, genReportResponse, genUser.copy(email = recipient)))
       )
 
-    def build(theReport: Report, reportResponse: ReportResponse, user: User): Email =
-      new ProFilteredEmailSingleReport {
-        override val report: Report                 = theReport
-        override val recipients: List[EmailAddress] = List(user.email)
-        override val subject: String                = EmailSubjects.REPORT_ACK_PRO
+    final case class EmailImpl(report: Report, reportResponse: ReportResponse, user: User)
+        extends ProFilteredEmailSingleReport {
+      override val recipients: List[EmailAddress] = List(user.email)
+      override val subject: String                = EmailSubjects.REPORT_ACK_PRO
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (frontRoute, _) =>
-            views.html.mails.professional.reportAcknowledgmentPro(reportResponse, user)(frontRoute).toString
-
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) =>
+          views.html.mails.professional.reportAcknowledgmentPro(reportResponse, user)(frontRoute).toString
+    }
   }
 
   case object ProResponseAcknowledgmentOnAdminCompletion extends EmailDefinition {
@@ -120,20 +133,17 @@ object EmailDefinitionsPro {
     override def examples =
       Seq(
         "report_ack_pro_on_admin_completion" -> ((recipient, _) =>
-          build(genReport, List(genUser.copy(email = recipient), genUser, genUser))
+          EmailImpl(genReport, List(genUser.copy(email = recipient), genUser, genUser))
         )
       )
 
-    def build(theReport: Report, users: List[User]): Email =
-      new ProFilteredEmailSingleReport {
-        override val report: Report                 = theReport
-        override val recipients: List[EmailAddress] = users.map(_.email)
-        override val subject: String                = EmailSubjects.REPORT_ACK_PRO_ON_ADMIN_COMPLETION
+    final case class EmailImpl(report: Report, users: List[User]) extends ProFilteredEmailSingleReport {
+      override val recipients: List[EmailAddress] = users.map(_.email)
+      override val subject: String                = EmailSubjects.REPORT_ACK_PRO_ON_ADMIN_COMPLETION
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (frontRoute, _) => views.html.mails.professional.reportAcknowledgmentProOnAdminCompletion(frontRoute).toString
-
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) => views.html.mails.professional.reportAcknowledgmentProOnAdminCompletion(frontRoute).toString
+    }
   }
 
   case object ProNewReportNotification extends EmailDefinition {
@@ -141,19 +151,17 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_notification" -> ((recipient, _) => build(NonEmptyList.of(recipient), genReport))
+        "report_notification" -> ((recipient, _) => EmailImpl(NonEmptyList.of(recipient), genReport))
       )
 
-    def build(userList: NonEmptyList[EmailAddress], theReport: Report): Email =
-      new ProFilteredEmailSingleReport {
-        override val report: Report                 = theReport
-        override val subject: String                = EmailSubjects.NEW_REPORT
-        override val recipients: List[EmailAddress] = userList.toList
+    final case class EmailImpl(userList: NonEmptyList[EmailAddress], report: Report)
+        extends ProFilteredEmailSingleReport {
+      override val subject: String                = EmailSubjects.NEW_REPORT
+      override val recipients: List[EmailAddress] = userList.toList
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (frontRoute, _) => views.html.mails.professional.reportNotification(report)(frontRoute).toString
-
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) => views.html.mails.professional.reportNotification(report)(frontRoute).toString
+    }
   }
 
   case object ProReportReOpeningNotification extends EmailDefinition {
@@ -161,18 +169,17 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_reopening_notification" -> ((recipient, _) => build(List(recipient), genReport))
+        "report_reopening_notification" -> ((recipient, _) => EmailImpl(List(recipient), genReport))
       )
 
-    def build(userList: List[EmailAddress], theReport: Report): Email =
-      new ProFilteredEmailSingleReport {
-        override val report: Report                 = theReport
-        override val subject: String                = EmailSubjects.REPORT_REOPENING
-        override val recipients: List[EmailAddress] = userList.toList
+    final case class EmailImpl(userList: List[EmailAddress], report: Report) extends ProFilteredEmailSingleReport {
+      override val subject: String                = EmailSubjects.REPORT_REOPENING
+      override val recipients: List[EmailAddress] = userList.toList
 
-        override def getBody: (FrontRoute, EmailAddress) => String =
-          (frontRoute, _) => views.html.mails.professional.reportReOpening(report)(frontRoute).toString
-      }
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) => views.html.mails.professional.reportReOpening(report)(frontRoute).toString
+    }
+
   }
 
   case object ProReportsReadReminder extends EmailDefinition {

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -105,4 +105,26 @@ object EmailDefinitionsPro {
       }
   }
 
+  case object ProResponseAcknowledgmentOnAdminCompletion extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq(
+        "report_ack_pro_on_admin_completion" -> (recipient =>
+          build(genReport, List(genUser.copy(email = recipient), genUser, genUser))
+        )
+      )
+
+    def build(theReport: Report, users: List[User]): Email =
+      new ProFilteredEmailSingleReport {
+        override val report: Report                 = theReport
+        override val recipients: List[EmailAddress] = users.map(_.email)
+        override val subject: String                = EmailSubjects.REPORT_ACK_PRO_ON_ADMIN_COMPLETION
+
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (frontRoute, _) => views.html.mails.professional.reportAcknowledgmentProOnAdminCompletion(frontRoute).toString
+
+      }
+  }
+
 }

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -65,4 +65,23 @@ object EmailDefinitionsPro {
       }
   }
 
+  case object ProNewCompaniesAccesses extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq("new_companies_accesses" -> (recipient => build(recipient, genCompanyList, genSiren)))
+
+    def build(recipient: EmailAddress, companies: List[Company], siren: SIREN): Email =
+      new Email {
+        override val recipients: List[EmailAddress] = List(recipient)
+        override val subject: String                = EmailSubjects.PRO_NEW_COMPANIES_ACCESSES(siren)
+
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (frontRoute, _) =>
+            views.html.mails.professional
+              .newCompaniesAccessesNotification(frontRoute.dashboard.login, companies, siren.value)(frontRoute)
+              .toString
+      }
+  }
+
 }

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -148,4 +148,23 @@ object EmailDefinitionsPro {
       }
   }
 
+  case object ProReportReOpeningNotification extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq(
+        "report_reopening_notification" -> (recipient => build(List(recipient), genReport))
+      )
+
+    def build(userList: List[EmailAddress], theReport: Report): Email =
+      new ProFilteredEmailSingleReport {
+        override val report: Report                 = theReport
+        override val subject: String                = EmailSubjects.REPORT_REOPENING
+        override val recipients: List[EmailAddress] = userList.toList
+
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (frontRoute, _) => views.html.mails.professional.reportReOpening(report)(frontRoute).toString
+      }
+  }
+
 }

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -1,5 +1,6 @@
 package services.emails
 
+import cats.data.NonEmptyList
 import models.User
 import models.company.Company
 import models.report.Report
@@ -123,6 +124,26 @@ object EmailDefinitionsPro {
 
         override def getBody: (FrontRoute, EmailAddress) => String =
           (frontRoute, _) => views.html.mails.professional.reportAcknowledgmentProOnAdminCompletion(frontRoute).toString
+
+      }
+  }
+
+  case object ProNewReportNotification extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq(
+        "report_notification" -> (recipient => build(NonEmptyList.of(recipient), genReport))
+      )
+
+    def build(userList: NonEmptyList[EmailAddress], theReport: Report): Email =
+      new ProFilteredEmailSingleReport {
+        override val report: Report                 = theReport
+        override val subject: String                = EmailSubjects.NEW_REPORT
+        override val recipients: List[EmailAddress] = userList.toList
+
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (frontRoute, _) => views.html.mails.professional.reportNotification(report)(frontRoute).toString
 
       }
   }

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -22,7 +22,7 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("access_invitation" -> (recipient => build(recipient, genCompany, dummyURL, None)))
+      Seq("access_invitation" -> ((recipient, _) => build(recipient, genCompany, dummyURL, None)))
 
     def build(recipient: EmailAddress, company: Company, invitationUrl: URI, invitedBy: Option[User]): Email =
       new Email {
@@ -38,7 +38,11 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("access_invitation_multiple_companies" -> (recipient => build(recipient, genCompanyList, genSiren, dummyURL)))
+      Seq(
+        "access_invitation_multiple_companies" -> ((recipient, _) =>
+          build(recipient, genCompanyList, genSiren, dummyURL)
+        )
+      )
 
     def build(recipient: EmailAddress, companies: List[Company], siren: SIREN, invitationUrl: URI): Email =
       new Email {
@@ -55,7 +59,7 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("new_company_access" -> (recipient => build(recipient, genCompany, None)))
+      Seq("new_company_access" -> ((recipient, _) => build(recipient, genCompany, None)))
 
     def build(recipient: EmailAddress, company: Company, invitedBy: Option[User]): Email =
       new Email {
@@ -74,7 +78,7 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("new_companies_accesses" -> (recipient => build(recipient, genCompanyList, genSiren)))
+      Seq("new_companies_accesses" -> ((recipient, _) => build(recipient, genCompanyList, genSiren)))
 
     def build(recipient: EmailAddress, companies: List[Company], siren: SIREN): Email =
       new Email {
@@ -93,7 +97,9 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("report_ack_pro" -> (recipient => build(genReport, genReportResponse, genUser.copy(email = recipient))))
+      Seq(
+        "report_ack_pro" -> ((recipient, _) => build(genReport, genReportResponse, genUser.copy(email = recipient)))
+      )
 
     def build(theReport: Report, reportResponse: ReportResponse, user: User): Email =
       new ProFilteredEmailSingleReport {
@@ -113,7 +119,7 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_ack_pro_on_admin_completion" -> (recipient =>
+        "report_ack_pro_on_admin_completion" -> ((recipient, _) =>
           build(genReport, List(genUser.copy(email = recipient), genUser, genUser))
         )
       )
@@ -135,7 +141,7 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_notification" -> (recipient => build(NonEmptyList.of(recipient), genReport))
+        "report_notification" -> ((recipient, _) => build(NonEmptyList.of(recipient), genReport))
       )
 
     def build(userList: NonEmptyList[EmailAddress], theReport: Report): Email =
@@ -155,7 +161,7 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_reopening_notification" -> (recipient => build(List(recipient), genReport))
+        "report_reopening_notification" -> ((recipient, _) => build(List(recipient), genReport))
       )
 
     def build(userList: List[EmailAddress], theReport: Report): Email =
@@ -177,7 +183,7 @@ object EmailDefinitionsPro {
       val report2 = genReport.copy(companyId = report1.companyId)
       val report3 = genReport.copy(companyId = report1.companyId, expirationDate = OffsetDateTime.now().plusDays(5))
       Seq(
-        "reports_transmitted_reminder" -> (recipient =>
+        "reports_transmitted_reminder" -> ((recipient, _) =>
           EmailImpl(List(recipient), List(report1, report2, report3), Period.ofDays(7))
         )
       )
@@ -205,7 +211,7 @@ object EmailDefinitionsPro {
       val report3 = genReport.copy(companyId = report1.companyId, expirationDate = OffsetDateTime.now().plusDays(5))
 
       Seq(
-        "reports_unread_reminder" -> (recipient =>
+        "reports_unread_reminder" -> ((recipient, _) =>
           EmailImpl(List(recipient), List(report1, report2, report3), Period.ofDays(7))
         )
       )
@@ -228,7 +234,7 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_assignement_to_other" -> (recipient =>
+        "report_assignement_to_other" -> ((recipient, _) =>
           EmailImpl(report = genReport, assigningUser = genUser, assignedUser = genUser.copy(email = recipient))
         )
       )

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -13,6 +13,8 @@ import utils.FrontRoute
 import utils.SIREN
 
 import java.net.URI
+import java.time.OffsetDateTime
+import java.time.Period
 
 object EmailDefinitionsPro {
 
@@ -165,6 +167,33 @@ object EmailDefinitionsPro {
         override def getBody: (FrontRoute, EmailAddress) => String =
           (frontRoute, _) => views.html.mails.professional.reportReOpening(report)(frontRoute).toString
       }
+  }
+
+  case object ProReportsReadReminder extends EmailDefinition {
+    override val category = Pro
+
+    override def examples = {
+      val report1 = genReport
+      val report2 = genReport.copy(companyId = report1.companyId)
+      val report3 = genReport.copy(companyId = report1.companyId, expirationDate = OffsetDateTime.now().plusDays(5))
+      Seq(
+        "reports_transmitted_reminder" -> (recipient =>
+          EmailImpl(List(recipient), List(report1, report2, report3), Period.ofDays(7))
+        )
+      )
+    }
+
+    case class EmailImpl(
+        recipients: List[EmailAddress],
+        reports: List[Report],
+        period: Period
+    ) extends ProFilteredEmailMultipleReport {
+      override val subject: String = EmailSubjects.REPORT_TRANSMITTED_REMINDER
+
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) =>
+          views.html.mails.professional.reportsTransmittedReminder(reports, period)(frontRoute).toString
+    }
   }
 
 }

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -22,14 +22,14 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("access_invitation" -> ((recipient, _) => EmailImpl(recipient, genCompany, dummyURL, None)))
+      Seq("access_invitation" -> ((recipient, _) => Email(recipient, genCompany, dummyURL, None)))
 
-    final case class EmailImpl(
+    final case class Email(
         recipient: EmailAddress,
         company: Company,
         invitationUrl: URI,
         invitedBy: Option[User]
-    ) extends Email {
+    ) extends BaseEmail {
       override val recipients: List[EmailAddress] = List(recipient)
       override val subject: String                = EmailSubjects.COMPANY_ACCESS_INVITATION(company.name)
 
@@ -45,16 +45,16 @@ object EmailDefinitionsPro {
     override def examples =
       Seq(
         "access_invitation_multiple_companies" -> ((recipient, _) =>
-          EmailImpl(recipient, genCompanyList, genSiren, dummyURL)
+          Email(recipient, genCompanyList, genSiren, dummyURL)
         )
       )
 
-    final case class EmailImpl(
+    final case class Email(
         recipient: EmailAddress,
         companies: List[Company],
         siren: SIREN,
         invitationUrl: URI
-    ) extends Email {
+    ) extends BaseEmail {
       override val recipients: List[EmailAddress] = List(recipient)
       override val subject: String                = EmailSubjects.PRO_COMPANIES_ACCESSES_INVITATIONS(siren)
 
@@ -68,13 +68,13 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("new_company_access" -> ((recipient, _) => EmailImpl(recipient, genCompany, None)))
+      Seq("new_company_access" -> ((recipient, _) => Email(recipient, genCompany, None)))
 
-    final case class EmailImpl(
+    final case class Email(
         recipient: EmailAddress,
         company: Company,
         invitedBy: Option[User]
-    ) extends Email {
+    ) extends BaseEmail {
       override val recipients: List[EmailAddress] = List(recipient)
       override val subject: String                = EmailSubjects.NEW_COMPANY_ACCESS(company.name)
 
@@ -90,13 +90,13 @@ object EmailDefinitionsPro {
     override val category = Pro
 
     override def examples =
-      Seq("new_companies_accesses" -> ((recipient, _) => EmailImpl(recipient, genCompanyList, genSiren)))
+      Seq("new_companies_accesses" -> ((recipient, _) => Email(recipient, genCompanyList, genSiren)))
 
-    final case class EmailImpl(
+    final case class Email(
         recipient: EmailAddress,
         companies: List[Company],
         siren: SIREN
-    ) extends Email {
+    ) extends BaseEmail {
       override val recipients: List[EmailAddress] = List(recipient)
       override val subject: String                = EmailSubjects.PRO_NEW_COMPANIES_ACCESSES(siren)
 
@@ -113,10 +113,10 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_ack_pro" -> ((recipient, _) => EmailImpl(genReport, genReportResponse, genUser.copy(email = recipient)))
+        "report_ack_pro" -> ((recipient, _) => Email(genReport, genReportResponse, genUser.copy(email = recipient)))
       )
 
-    final case class EmailImpl(report: Report, reportResponse: ReportResponse, user: User)
+    final case class Email(report: Report, reportResponse: ReportResponse, user: User)
         extends ProFilteredEmailSingleReport {
       override val recipients: List[EmailAddress] = List(user.email)
       override val subject: String                = EmailSubjects.REPORT_ACK_PRO
@@ -133,11 +133,11 @@ object EmailDefinitionsPro {
     override def examples =
       Seq(
         "report_ack_pro_on_admin_completion" -> ((recipient, _) =>
-          EmailImpl(genReport, List(genUser.copy(email = recipient), genUser, genUser))
+          Email(genReport, List(genUser.copy(email = recipient), genUser, genUser))
         )
       )
 
-    final case class EmailImpl(report: Report, users: List[User]) extends ProFilteredEmailSingleReport {
+    final case class Email(report: Report, users: List[User]) extends ProFilteredEmailSingleReport {
       override val recipients: List[EmailAddress] = users.map(_.email)
       override val subject: String                = EmailSubjects.REPORT_ACK_PRO_ON_ADMIN_COMPLETION
 
@@ -151,11 +151,10 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_notification" -> ((recipient, _) => EmailImpl(NonEmptyList.of(recipient), genReport))
+        "report_notification" -> ((recipient, _) => Email(NonEmptyList.of(recipient), genReport))
       )
 
-    final case class EmailImpl(userList: NonEmptyList[EmailAddress], report: Report)
-        extends ProFilteredEmailSingleReport {
+    final case class Email(userList: NonEmptyList[EmailAddress], report: Report) extends ProFilteredEmailSingleReport {
       override val subject: String                = EmailSubjects.NEW_REPORT
       override val recipients: List[EmailAddress] = userList.toList
 
@@ -169,10 +168,10 @@ object EmailDefinitionsPro {
 
     override def examples =
       Seq(
-        "report_reopening_notification" -> ((recipient, _) => EmailImpl(List(recipient), genReport))
+        "report_reopening_notification" -> ((recipient, _) => Email(List(recipient), genReport))
       )
 
-    final case class EmailImpl(userList: List[EmailAddress], report: Report) extends ProFilteredEmailSingleReport {
+    final case class Email(userList: List[EmailAddress], report: Report) extends ProFilteredEmailSingleReport {
       override val subject: String                = EmailSubjects.REPORT_REOPENING
       override val recipients: List[EmailAddress] = userList.toList
 
@@ -191,12 +190,12 @@ object EmailDefinitionsPro {
       val report3 = genReport.copy(companyId = report1.companyId, expirationDate = OffsetDateTime.now().plusDays(5))
       Seq(
         "reports_transmitted_reminder" -> ((recipient, _) =>
-          EmailImpl(List(recipient), List(report1, report2, report3), Period.ofDays(7))
+          Email(List(recipient), List(report1, report2, report3), Period.ofDays(7))
         )
       )
     }
 
-    final case class EmailImpl(
+    final case class Email(
         recipients: List[EmailAddress],
         reports: List[Report],
         period: Period
@@ -219,12 +218,12 @@ object EmailDefinitionsPro {
 
       Seq(
         "reports_unread_reminder" -> ((recipient, _) =>
-          EmailImpl(List(recipient), List(report1, report2, report3), Period.ofDays(7))
+          Email(List(recipient), List(report1, report2, report3), Period.ofDays(7))
         )
       )
     }
 
-    final case class EmailImpl(
+    final case class Email(
         recipients: List[EmailAddress],
         reports: List[Report],
         period: Period
@@ -242,11 +241,11 @@ object EmailDefinitionsPro {
     override def examples =
       Seq(
         "report_assignement_to_other" -> ((recipient, _) =>
-          EmailImpl(report = genReport, assigningUser = genUser, assignedUser = genUser.copy(email = recipient))
+          Email(report = genReport, assigningUser = genUser, assignedUser = genUser.copy(email = recipient))
         )
       )
 
-    final case class EmailImpl(report: Report, assigningUser: User, assignedUser: User)
+    final case class Email(report: Report, assigningUser: User, assignedUser: User)
         extends ProFilteredEmailSingleReport {
       override val recipients: List[EmailAddress] = List(assignedUser.email)
       override val subject: String                = EmailSubjects.REPORT_ASSIGNED

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -183,7 +183,7 @@ object EmailDefinitionsPro {
       )
     }
 
-    case class EmailImpl(
+    final case class EmailImpl(
         recipients: List[EmailAddress],
         reports: List[Report],
         period: Period
@@ -193,6 +193,33 @@ object EmailDefinitionsPro {
       override def getBody: (FrontRoute, EmailAddress) => String =
         (frontRoute, _) =>
           views.html.mails.professional.reportsTransmittedReminder(reports, period)(frontRoute).toString
+    }
+  }
+
+  case object ProReportsUnreadReminder extends EmailDefinition {
+    override val category = Pro
+
+    override def examples = {
+      val report1 = genReport
+      val report2 = genReport.copy(companyId = report1.companyId)
+      val report3 = genReport.copy(companyId = report1.companyId, expirationDate = OffsetDateTime.now().plusDays(5))
+
+      Seq(
+        "reports_unread_reminder" -> (recipient =>
+          EmailImpl(List(recipient), List(report1, report2, report3), Period.ofDays(7))
+        )
+      )
+    }
+
+    final case class EmailImpl(
+        recipients: List[EmailAddress],
+        reports: List[Report],
+        period: Period
+    ) extends ProFilteredEmailMultipleReport {
+      override val subject: String = EmailSubjects.REPORT_UNREAD_REMINDER
+
+      override def getBody: (FrontRoute, EmailAddress) => String =
+        (frontRoute, _) => views.html.mails.professional.reportsUnreadReminder(reports, period)(frontRoute).toString
     }
   }
 

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -46,4 +46,23 @@ object EmailDefinitionsPro {
       }
   }
 
+  case object ProNewCompanyAccess extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq("new_company_access" -> (recipient => build(recipient, genCompany, None)))
+
+    def build(recipient: EmailAddress, company: Company, invitedBy: Option[User]): Email =
+      new Email {
+        override val recipients: List[EmailAddress] = List(recipient)
+        override val subject: String                = EmailSubjects.NEW_COMPANY_ACCESS(company.name)
+
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (frontRoute, _) =>
+            views.html.mails.professional
+              .newCompanyAccessNotification(frontRoute.dashboard.login, company, invitedBy)(frontRoute)
+              .toString
+      }
+  }
+
 }

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -7,6 +7,7 @@ import services.emails.EmailsExamplesUtils._
 import utils.EmailAddress
 import utils.EmailSubjects
 import utils.FrontRoute
+import utils.SIREN
 
 import java.net.URI
 
@@ -22,8 +23,26 @@ object EmailDefinitionsPro {
       new Email {
         override val recipients: List[EmailAddress] = List(recipient)
         override val subject: String                = EmailSubjects.COMPANY_ACCESS_INVITATION(company.name)
+
         override def getBody: (FrontRoute, EmailAddress) => String =
           (_, _) => views.html.mails.professional.companyAccessInvitation(invitationUrl, company, invitedBy).toString
+      }
+  }
+
+  case object ProCompaniesAccessesInvitations extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq("access_invitation_multiple_companies" -> (recipient => build(recipient, genCompanyList, genSiren, dummyURL)))
+
+    def build(recipient: EmailAddress, companies: List[Company], siren: SIREN, invitationUrl: URI): Email =
+      new Email {
+        override val recipients: List[EmailAddress] = List(recipient)
+        override val subject: String                = EmailSubjects.PRO_COMPANIES_ACCESSES_INVITATIONS(siren)
+
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (_, _) =>
+            views.html.mails.professional.companiesAccessesInvitations(invitationUrl, companies, siren.value).toString
       }
   }
 

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -1,0 +1,30 @@
+package services.emails
+
+import models.User
+import models.company.Company
+import services.emails.EmailCategory.Pro
+import services.emails.EmailsExamplesUtils._
+import utils.EmailAddress
+import utils.EmailSubjects
+import utils.FrontRoute
+
+import java.net.URI
+
+object EmailDefinitionsPro {
+
+  case object ProCompanyAccessInvitation extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq("access_invitation" -> (recipient => build(recipient, genCompany, dummyURL, None)))
+
+    def build(recipient: EmailAddress, company: Company, invitationUrl: URI, invitedBy: Option[User]): Email =
+      new Email {
+        override val recipients: List[EmailAddress] = List(recipient)
+        override val subject: String                = EmailSubjects.COMPANY_ACCESS_INVITATION(company.name)
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (_, _) => views.html.mails.professional.companyAccessInvitation(invitationUrl, company, invitedBy).toString
+      }
+  }
+
+}

--- a/app/services/emails/EmailDefinitionsPro.scala
+++ b/app/services/emails/EmailDefinitionsPro.scala
@@ -2,6 +2,8 @@ package services.emails
 
 import models.User
 import models.company.Company
+import models.report.Report
+import models.report.ReportResponse
 import services.emails.EmailCategory.Pro
 import services.emails.EmailsExamplesUtils._
 import utils.EmailAddress
@@ -81,6 +83,25 @@ object EmailDefinitionsPro {
             views.html.mails.professional
               .newCompaniesAccessesNotification(frontRoute.dashboard.login, companies, siren.value)(frontRoute)
               .toString
+      }
+  }
+
+  case object ProResponseAcknowledgment extends EmailDefinition {
+    override val category = Pro
+
+    override def examples =
+      Seq("report_ack_pro" -> (recipient => build(genReport, genReportResponse, genUser.copy(email = recipient))))
+
+    def build(theReport: Report, reportResponse: ReportResponse, user: User): Email =
+      new ProFilteredEmailSingleReport {
+        override val report: Report                 = theReport
+        override val recipients: List[EmailAddress] = List(user.email)
+        override val subject: String                = EmailSubjects.REPORT_ACK_PRO
+
+        override def getBody: (FrontRoute, EmailAddress) => String =
+          (frontRoute, _) =>
+            views.html.mails.professional.reportAcknowledgmentPro(reportResponse, user)(frontRoute).toString
+
       }
   }
 

--- a/app/services/emails/EmailDefinitionsVarious.scala
+++ b/app/services/emails/EmailDefinitionsVarious.scala
@@ -1,42 +1,19 @@
 package services.emails
 
-import enumeratum.EnumEntry
-import enumeratum.PlayEnum
 import models.User
 import models.auth.AuthToken
-import EmailsExamplesUtils._
 import services.emails.EmailCategory.Various
+import services.emails.EmailsExamplesUtils._
 import utils.EmailAddress
 import utils.EmailSubjects
 import utils.FrontRoute
 
 import java.net.URI
-
-sealed trait EmailCategory extends EnumEntry
-
-object EmailCategory extends PlayEnum[EmailCategory] {
-  override def values: IndexedSeq[EmailCategory] = findValues
-
-  case object Various extends EmailCategory
-
-  case object Admin extends EmailCategory
-
-  case object Dgccrf extends EmailCategory
-  case object Pro    extends EmailCategory
-  case object Conso  extends EmailCategory
-
-}
-
-trait EmailDefinition {
-  val category: EmailCategory
-  def examples: Seq[(String, EmailAddress => Email)]
-
-}
-
-object EmailDefinitions {
+object EmailDefinitionsVarious {
 
   case object ResetPassword extends EmailDefinition {
     override val category = Various
+
     override def examples =
       Seq("reset_password" -> (recipient => build(genUser.copy(email = recipient), genAuthToken)))
 
@@ -44,6 +21,7 @@ object EmailDefinitions {
       new Email {
         override val recipients: List[EmailAddress] = List(user.email)
         override val subject: String                = EmailSubjects.RESET_PASSWORD
+
         override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
           views.html.mails.resetPassword(user, authToken)(frontRoute, contactAddress).toString
       }
@@ -59,9 +37,9 @@ object EmailDefinitions {
       new Email {
         override val recipients: List[EmailAddress] = List(recipient)
         override val subject: String                = EmailSubjects.UPDATE_EMAIL_ADDRESS
+
         override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
           views.html.mails.updateEmailAddress(invitationUrl, daysBeforeExpiry).toString()
       }
   }
-
 }

--- a/app/services/emails/EmailDefinitionsVarious.scala
+++ b/app/services/emails/EmailDefinitionsVarious.scala
@@ -14,7 +14,7 @@ object EmailDefinitionsVarious {
   case object ResetPassword extends EmailDefinition {
     override val category = Various
 
-    final case class EmailImpl(user: User, authToken: AuthToken) extends Email {
+    final case class Email(user: User, authToken: AuthToken) extends BaseEmail {
       override val recipients: List[EmailAddress] = List(user.email)
       override val subject: String                = EmailSubjects.RESET_PASSWORD
       override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
@@ -22,14 +22,14 @@ object EmailDefinitionsVarious {
     }
 
     override def examples =
-      Seq("reset_password" -> ((recipient, _) => EmailImpl(genUser.copy(email = recipient), genAuthToken)))
+      Seq("reset_password" -> ((recipient, _) => Email(genUser.copy(email = recipient), genAuthToken)))
 
   }
 
   case object UpdateEmailAddress extends EmailDefinition {
     override val category = Various
 
-    final case class EmailImpl(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int) extends Email {
+    final case class Email(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int) extends BaseEmail {
 
       override val recipients: Seq[EmailAddress] = List(recipient)
       override val subject: String               = EmailSubjects.UPDATE_EMAIL_ADDRESS
@@ -38,7 +38,7 @@ object EmailDefinitionsVarious {
         views.html.mails.updateEmailAddress(invitationUrl, daysBeforeExpiry).toString()
     }
     override def examples =
-      Seq("update_email_address" -> ((recipient, _) => EmailImpl(recipient, dummyURL, daysBeforeExpiry = 2)))
+      Seq("update_email_address" -> ((recipient, _) => Email(recipient, dummyURL, daysBeforeExpiry = 2)))
 
   }
 }

--- a/app/services/emails/EmailDefinitionsVarious.scala
+++ b/app/services/emails/EmailDefinitionsVarious.scala
@@ -15,7 +15,7 @@ object EmailDefinitionsVarious {
     override val category = Various
 
     override def examples =
-      Seq("reset_password" -> (recipient => build(genUser.copy(email = recipient), genAuthToken)))
+      Seq("reset_password" -> ((recipient, _) => build(genUser.copy(email = recipient), genAuthToken)))
 
     def build(user: User, authToken: AuthToken): Email =
       new Email {
@@ -31,7 +31,7 @@ object EmailDefinitionsVarious {
     override val category = Various
 
     override def examples =
-      Seq("update_email_address" -> (recipient => build(recipient, dummyURL, daysBeforeExpiry = 2)))
+      Seq("update_email_address" -> ((recipient, _) => build(recipient, dummyURL, daysBeforeExpiry = 2)))
 
     def build(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int): Email =
       new Email {

--- a/app/services/emails/EmailDefinitionsVarious.scala
+++ b/app/services/emails/EmailDefinitionsVarious.scala
@@ -14,32 +14,31 @@ object EmailDefinitionsVarious {
   case object ResetPassword extends EmailDefinition {
     override val category = Various
 
+    final case class EmailImpl(user: User, authToken: AuthToken) extends Email {
+      override val recipients: List[EmailAddress] = List(user.email)
+      override val subject: String                = EmailSubjects.RESET_PASSWORD
+      override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
+        views.html.mails.resetPassword(user, authToken)(frontRoute, contactAddress).toString
+    }
+
     override def examples =
-      Seq("reset_password" -> ((recipient, _) => build(genUser.copy(email = recipient), genAuthToken)))
+      Seq("reset_password" -> ((recipient, _) => EmailImpl(genUser.copy(email = recipient), genAuthToken)))
 
-    def build(user: User, authToken: AuthToken): Email =
-      new Email {
-        override val recipients: List[EmailAddress] = List(user.email)
-        override val subject: String                = EmailSubjects.RESET_PASSWORD
-
-        override def getBody: (FrontRoute, EmailAddress) => String = (frontRoute, contactAddress) =>
-          views.html.mails.resetPassword(user, authToken)(frontRoute, contactAddress).toString
-      }
   }
 
   case object UpdateEmailAddress extends EmailDefinition {
     override val category = Various
 
+    final case class EmailImpl(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int) extends Email {
+
+      override val recipients: Seq[EmailAddress] = List(recipient)
+      override val subject: String               = EmailSubjects.UPDATE_EMAIL_ADDRESS
+
+      override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
+        views.html.mails.updateEmailAddress(invitationUrl, daysBeforeExpiry).toString()
+    }
     override def examples =
-      Seq("update_email_address" -> ((recipient, _) => build(recipient, dummyURL, daysBeforeExpiry = 2)))
+      Seq("update_email_address" -> ((recipient, _) => EmailImpl(recipient, dummyURL, daysBeforeExpiry = 2)))
 
-    def build(recipient: EmailAddress, invitationUrl: URI, daysBeforeExpiry: Int): Email =
-      new Email {
-        override val recipients: List[EmailAddress] = List(recipient)
-        override val subject: String                = EmailSubjects.UPDATE_EMAIL_ADDRESS
-
-        override def getBody: (FrontRoute, EmailAddress) => String = (_, _) =>
-          views.html.mails.updateEmailAddress(invitationUrl, daysBeforeExpiry).toString()
-      }
   }
 }

--- a/app/services/emails/Emails.scala
+++ b/app/services/emails/Emails.scala
@@ -1,11 +1,11 @@
-package services
+package services.emails
 
 import enumeratum.EnumEntry
 import enumeratum.PlayEnum
 import models.User
 import models.auth.AuthToken
-import services.EmailCategory.Various
-import services.EmailsExamplesUtils._
+import EmailsExamplesUtils._
+import services.emails.EmailCategory.Various
 import utils.EmailAddress
 import utils.EmailSubjects
 import utils.FrontRoute

--- a/app/services/emails/EmailsExamplesUtils.scala
+++ b/app/services/emails/EmailsExamplesUtils.scala
@@ -69,8 +69,8 @@ object EmailsExamplesUtils {
     responseType = ReportResponseType.ACCEPTED,
     responseDetails = Some(ResponseDetails.REFUND),
     otherResponseDetails = None,
-    consumerDetails = "",
-    dgccrfDetails = Some(""),
+    consumerDetails = "blablabla",
+    dgccrfDetails = Some("ouplalalala"),
     fileIds = Nil
   )
 

--- a/app/services/emails/EmailsExamplesUtils.scala
+++ b/app/services/emails/EmailsExamplesUtils.scala
@@ -1,4 +1,4 @@
-package services
+package services.emails
 
 import models.Subscription
 import models.User
@@ -9,14 +9,7 @@ import models.company.Company
 import models.event.Event
 import models.report.DetailInputValue.toDetailInputValue
 import models.report.ReportFileOrigin.Consumer
-import models.report.Gender
-import models.report.Report
-import models.report.ReportFile
-import models.report.ReportResponse
-import models.report.ReportResponseType
-import models.report.ReportStatus
-import models.report.ResponseDetails
-import models.report.WebsiteURL
+import models.report._
 import models.report.reportfile.ReportFileId
 import utils.Constants.ActionEvent.POST_ACCOUNT_ACTIVATION_DOC
 import utils.Constants.EventType

--- a/app/services/emails/MailRetriesService.scala
+++ b/app/services/emails/MailRetriesService.scala
@@ -1,21 +1,21 @@
-package services
+package services.emails
 
 import akka.actor.ActorSystem
 import cats.data.NonEmptyList
 import com.sun.mail.smtp.SMTPSendFailedException
 import play.api.Logger
 import play.api.libs.mailer._
-import services.MailRetriesService.EmailRequest
-import services.MailRetriesService.getDelayBeforeNextRetry
+import services.emails.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.getDelayBeforeNextRetry
 import utils.EmailAddress
 import utils.Logs.RichLogger
 
 import java.util.concurrent.Executors
 import javax.mail.internet.AddressException
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import scala.concurrent.duration.DurationDouble
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Random
 import scala.util.Success

--- a/app/services/emails/MailService.scala
+++ b/app/services/emails/MailService.scala
@@ -1,11 +1,13 @@
-package services
+package services.emails
 
 import cats.data.NonEmptyList
 import config.EmailConfiguration
 import play.api.Logger
 import play.api.libs.mailer.Attachment
 import repositories.reportblockednotification.ReportNotificationBlockedRepositoryInterface
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
+import services.AttachmentService
+import services.PDFService
 import utils.EmailAddress
 import utils.FrontRoute
 

--- a/app/services/emails/MailService.scala
+++ b/app/services/emails/MailService.scala
@@ -30,7 +30,7 @@ class MailService(
   implicit private[this] val contactAddress: EmailAddress = emailConfiguration.contactAddress
 
   override def send(
-      email: Email
+      email: BaseEmail
   ): Future[Unit] = email match {
     case email: ProFilteredEmail => filterBlockedAndSend(email)
     case email =>

--- a/app/services/emails/MailServiceInterface.scala
+++ b/app/services/emails/MailServiceInterface.scala
@@ -3,5 +3,5 @@ package services.emails
 import scala.concurrent.Future
 
 trait MailServiceInterface {
-  def send(email: Email): Future[Unit]
+  def send(email: BaseEmail): Future[Unit]
 }

--- a/app/services/emails/MailServiceInterface.scala
+++ b/app/services/emails/MailServiceInterface.scala
@@ -1,4 +1,5 @@
-package services
+package services.emails
+
 import scala.concurrent.Future
 
 trait MailServiceInterface {

--- a/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
+++ b/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
@@ -57,7 +57,7 @@ class InactiveDgccrfAccountReminderTask(
     val now            = OffsetDateTime.now()
     val expirationDate = user.lastEmailValidation.map(_.plus(inactivePeriod))
     for {
-      _ <- mailService.send(DgccrfInactiveAccount.EmailImpl(user, expirationDate.map(_.toLocalDate)))
+      _ <- mailService.send(DgccrfInactiveAccount.Email(user, expirationDate.map(_.toLocalDate)))
       _ <- eventRepository.create(
         Event(
           UUID.randomUUID(),

--- a/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
+++ b/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
@@ -7,8 +7,8 @@ import play.api.Logger
 import play.api.libs.json.Json
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.Email.DgccrfInactiveAccount
-import services.MailService
+import services.emails.Email.DgccrfInactiveAccount
+import services.emails.MailService
 import utils.Constants.ActionEvent
 import utils.Constants.EventType
 import utils.Logs.RichLogger

--- a/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
+++ b/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
@@ -57,7 +57,7 @@ class InactiveDgccrfAccountReminderTask(
     val now            = OffsetDateTime.now()
     val expirationDate = user.lastEmailValidation.map(_.plus(inactivePeriod))
     for {
-      _ <- mailService.send(DgccrfInactiveAccount.build(user, expirationDate.map(_.toLocalDate)))
+      _ <- mailService.send(DgccrfInactiveAccount.EmailImpl(user, expirationDate.map(_.toLocalDate)))
       _ <- eventRepository.create(
         Event(
           UUID.randomUUID(),

--- a/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
+++ b/app/tasks/account/InactiveDgccrfAccountReminderTask.scala
@@ -7,7 +7,7 @@ import play.api.Logger
 import play.api.libs.json.Json
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.Email.DgccrfInactiveAccount
+import services.emails.EmailDefinitionsDggcrf.DgccrfInactiveAccount
 import services.emails.MailService
 import utils.Constants.ActionEvent
 import utils.Constants.EventType
@@ -57,7 +57,7 @@ class InactiveDgccrfAccountReminderTask(
     val now            = OffsetDateTime.now()
     val expirationDate = user.lastEmailValidation.map(_.plus(inactivePeriod))
     for {
-      _ <- mailService.send(DgccrfInactiveAccount(user, expirationDate.map(_.toLocalDate)))
+      _ <- mailService.send(DgccrfInactiveAccount.build(user, expirationDate.map(_.toLocalDate)))
       _ <- eventRepository.create(
         Event(
           UUID.randomUUID(),

--- a/app/tasks/probe/LowRateLanceurDAlerteTask.scala
+++ b/app/tasks/probe/LowRateLanceurDAlerteTask.scala
@@ -7,7 +7,7 @@ import play.api.Logger
 import repositories.probe.ProbeRepository
 import repositories.tasklock.TaskRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.Email.AdminProbeTriggered
+import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.MailService
 import tasks.ScheduledTask
 import utils.Logs.RichLogger
@@ -38,7 +38,9 @@ class LowRateLanceurDAlerteTask(
       for {
         users <- userRepository.listForRoles(Seq(UserRole.Admin))
         _ <- mailService
-          .send(AdminProbeTriggered(users.map(_.email), "Taux de signalements 'Lanceur d'alerte' faible", rate, "bas"))
+          .send(
+            AdminProbeTriggered.build(users.map(_.email), "Taux de signalements 'Lanceur d'alerte' faible", rate, "bas")
+          )
       } yield ()
     case rate =>
       logger.debug(s"Taux de signalements correct: $rate%")

--- a/app/tasks/probe/LowRateLanceurDAlerteTask.scala
+++ b/app/tasks/probe/LowRateLanceurDAlerteTask.scala
@@ -39,7 +39,8 @@ class LowRateLanceurDAlerteTask(
         users <- userRepository.listForRoles(Seq(UserRole.Admin))
         _ <- mailService
           .send(
-            AdminProbeTriggered.build(users.map(_.email), "Taux de signalements 'Lanceur d'alerte' faible", rate, "bas")
+            AdminProbeTriggered
+              .EmailImpl(users.map(_.email), "Taux de signalements 'Lanceur d'alerte' faible", rate, "bas")
           )
       } yield ()
     case rate =>

--- a/app/tasks/probe/LowRateLanceurDAlerteTask.scala
+++ b/app/tasks/probe/LowRateLanceurDAlerteTask.scala
@@ -40,7 +40,7 @@ class LowRateLanceurDAlerteTask(
         _ <- mailService
           .send(
             AdminProbeTriggered
-              .EmailImpl(users.map(_.email), "Taux de signalements 'Lanceur d'alerte' faible", rate, "bas")
+              .Email(users.map(_.email), "Taux de signalements 'Lanceur d'alerte' faible", rate, "bas")
           )
       } yield ()
     case rate =>

--- a/app/tasks/probe/LowRateLanceurDAlerteTask.scala
+++ b/app/tasks/probe/LowRateLanceurDAlerteTask.scala
@@ -7,8 +7,8 @@ import play.api.Logger
 import repositories.probe.ProbeRepository
 import repositories.tasklock.TaskRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.Email.AdminProbeTriggered
-import services.MailService
+import services.emails.Email.AdminProbeTriggered
+import services.emails.MailService
 import tasks.ScheduledTask
 import utils.Logs.RichLogger
 

--- a/app/tasks/probe/LowRateReponseConsoTask.scala
+++ b/app/tasks/probe/LowRateReponseConsoTask.scala
@@ -39,7 +39,8 @@ class LowRateReponseConsoTask(
         users <- userRepository.listForRoles(Seq(UserRole.Admin))
         _ <- mailService
           .send(
-            AdminProbeTriggered.build(users.map(_.email), "Taux de signalements 'Réponse conso' faible", rate, "bas")
+            AdminProbeTriggered
+              .EmailImpl(users.map(_.email), "Taux de signalements 'Réponse conso' faible", rate, "bas")
           )
       } yield ()
     case rate =>

--- a/app/tasks/probe/LowRateReponseConsoTask.scala
+++ b/app/tasks/probe/LowRateReponseConsoTask.scala
@@ -7,16 +7,16 @@ import play.api.Logger
 import repositories.probe.ProbeRepository
 import repositories.tasklock.TaskRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.Email.AdminProbeTriggered
+import services.emails.EmailDefinitionsAdmin.AdminProbeTriggered
 import services.emails.MailService
 import tasks.ScheduledTask
 import utils.Logs.RichLogger
 
 import java.time.LocalTime
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
 
 class LowRateReponseConsoTask(
     actorSystem: ActorSystem,
@@ -38,7 +38,9 @@ class LowRateReponseConsoTask(
       for {
         users <- userRepository.listForRoles(Seq(UserRole.Admin))
         _ <- mailService
-          .send(AdminProbeTriggered(users.map(_.email), "Taux de signalements 'Réponse conso' faible", rate, "bas"))
+          .send(
+            AdminProbeTriggered.build(users.map(_.email), "Taux de signalements 'Réponse conso' faible", rate, "bas")
+          )
       } yield ()
     case rate =>
       logger.debug(s"Taux de signalements correct: $rate%")

--- a/app/tasks/probe/LowRateReponseConsoTask.scala
+++ b/app/tasks/probe/LowRateReponseConsoTask.scala
@@ -40,7 +40,7 @@ class LowRateReponseConsoTask(
         _ <- mailService
           .send(
             AdminProbeTriggered
-              .EmailImpl(users.map(_.email), "Taux de signalements 'Réponse conso' faible", rate, "bas")
+              .Email(users.map(_.email), "Taux de signalements 'Réponse conso' faible", rate, "bas")
           )
       } yield ()
     case rate =>

--- a/app/tasks/probe/LowRateReponseConsoTask.scala
+++ b/app/tasks/probe/LowRateReponseConsoTask.scala
@@ -7,8 +7,8 @@ import play.api.Logger
 import repositories.probe.ProbeRepository
 import repositories.tasklock.TaskRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.Email.AdminProbeTriggered
-import services.MailService
+import services.emails.Email.AdminProbeTriggered
+import services.emails.MailService
 import tasks.ScheduledTask
 import utils.Logs.RichLogger
 

--- a/app/tasks/report/ReportClosureTask.scala
+++ b/app/tasks/report/ReportClosureTask.scala
@@ -13,10 +13,10 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
-import services.Email.ConsumerReportClosedNoAction
-import services.Email.ConsumerReportClosedNoReading
-import services.ConsumerEmail
-import services.MailService
+import services.emails.Email.ConsumerReportClosedNoAction
+import services.emails.Email.ConsumerReportClosedNoReading
+import services.emails.ConsumerEmail
+import services.emails.MailService
 import tasks.ScheduledTask
 import tasks.getTodayAtStartOfDayParis
 import utils.Constants.ActionEvent.EMAIL_CONSUMER_REPORT_CLOSED_BY_NO_ACTION

--- a/app/tasks/report/ReportClosureTask.scala
+++ b/app/tasks/report/ReportClosureTask.scala
@@ -14,8 +14,8 @@ import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
 import services.emails.Email.ConsumerReportClosedNoAction
-import services.emails.Email.ConsumerReportClosedNoReading
-import services.emails.ConsumerEmail
+import services.emails.EmailDefinitionsConsumer.ConsumerReportClosedNoReading
+import services.emails.Email
 import services.emails.MailService
 import tasks.ScheduledTask
 import tasks.getTodayAtStartOfDayParis
@@ -25,6 +25,7 @@ import utils.Constants.ActionEvent.REPORT_CLOSED_BY_NO_ACTION
 import utils.Constants.ActionEvent.REPORT_CLOSED_BY_NO_READING
 import utils.Constants.EventType.CONSO
 import utils.Constants.EventType.SYSTEM
+import utils.Logs.RichLogger
 
 import java.time._
 import java.util.UUID
@@ -33,7 +34,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
-import utils.Logs.RichLogger
 
 class ReportClosureTask(
     actorSystem: ActorSystem,
@@ -96,7 +96,7 @@ class ReportClosureTask(
         ReportStatus.NonConsulte,
         REPORT_CLOSED_BY_NO_READING,
         "Clôture automatique : signalement non consulté",
-        ConsumerReportClosedNoReading,
+        ConsumerReportClosedNoReading.EmailImpl,
         EMAIL_CONSUMER_REPORT_CLOSED_BY_NO_READING
       )
     }
@@ -131,7 +131,7 @@ class ReportClosureTask(
     } yield ()
   }
 
-  private def eventuallySendConsumerEmail(report: Report, email: ConsumerEmail) = {
+  private def eventuallySendConsumerEmail(report: Report, email: Email) = {
     val hasReportBeenReOpened = report.reopenDate.isDefined
     // We don't want the consumer to be notified when a pro is requesting a report reopening.
     // The consumer will only be notified when the pro will reply.

--- a/app/tasks/report/ReportClosureTask.scala
+++ b/app/tasks/report/ReportClosureTask.scala
@@ -13,7 +13,7 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
-import services.emails.Email.ConsumerReportClosedNoAction
+import services.emails.EmailDefinitionsConsumer.ConsumerReportClosedNoAction
 import services.emails.EmailDefinitionsConsumer.ConsumerReportClosedNoReading
 import services.emails.Email
 import services.emails.MailService
@@ -88,7 +88,7 @@ class ReportClosureTask(
         ReportStatus.ConsulteIgnore,
         REPORT_CLOSED_BY_NO_ACTION,
         "Clôture automatique : signalement consulté ignoré",
-        ConsumerReportClosedNoAction,
+        ConsumerReportClosedNoAction.EmailImpl,
         EMAIL_CONSUMER_REPORT_CLOSED_BY_NO_ACTION
       )
     } else {

--- a/app/tasks/report/ReportClosureTask.scala
+++ b/app/tasks/report/ReportClosureTask.scala
@@ -15,7 +15,7 @@ import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
 import services.emails.EmailDefinitionsConsumer.ConsumerReportClosedNoAction
 import services.emails.EmailDefinitionsConsumer.ConsumerReportClosedNoReading
-import services.emails.Email
+import services.emails.BaseEmail
 import services.emails.MailService
 import tasks.ScheduledTask
 import tasks.getTodayAtStartOfDayParis
@@ -88,7 +88,7 @@ class ReportClosureTask(
         ReportStatus.ConsulteIgnore,
         REPORT_CLOSED_BY_NO_ACTION,
         "Clôture automatique : signalement consulté ignoré",
-        ConsumerReportClosedNoAction.EmailImpl,
+        ConsumerReportClosedNoAction.Email,
         EMAIL_CONSUMER_REPORT_CLOSED_BY_NO_ACTION
       )
     } else {
@@ -96,7 +96,7 @@ class ReportClosureTask(
         ReportStatus.NonConsulte,
         REPORT_CLOSED_BY_NO_READING,
         "Clôture automatique : signalement non consulté",
-        ConsumerReportClosedNoReading.EmailImpl,
+        ConsumerReportClosedNoReading.Email,
         EMAIL_CONSUMER_REPORT_CLOSED_BY_NO_READING
       )
     }
@@ -131,7 +131,7 @@ class ReportClosureTask(
     } yield ()
   }
 
-  private def eventuallySendConsumerEmail(report: Report, email: Email) = {
+  private def eventuallySendConsumerEmail(report: Report, email: BaseEmail) = {
     val hasReportBeenReOpened = report.reopenDate.isDefined
     // We don't want the consumer to be notified when a pro is requesting a report reopening.
     // The consumer will only be notified when the pro will reply.

--- a/app/tasks/report/ReportNotificationTask.scala
+++ b/app/tasks/report/ReportNotificationTask.scala
@@ -91,7 +91,7 @@ class ReportNotificationTask(
           s"Sending a subscription notification email to ${emailAddress}"
         )
         mailService.send {
-          DgccrfReportNotification.EmailImpl(
+          DgccrfReportNotification.Email(
             List(emailAddress),
             subscription,
             filteredReport.toList,

--- a/app/tasks/report/ReportNotificationTask.scala
+++ b/app/tasks/report/ReportNotificationTask.scala
@@ -15,8 +15,8 @@ import repositories.report.ReportRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.Email.DgccrfReportNotification
-import services.MailService
+import services.emails.Email.DgccrfReportNotification
+import services.emails.MailService
 import tasks.report.ReportNotificationTask.refineReportBasedOnSubscriptionFilters
 import tasks.ScheduledTask
 import utils.Constants.Departments

--- a/app/tasks/report/ReportNotificationTask.scala
+++ b/app/tasks/report/ReportNotificationTask.scala
@@ -91,7 +91,7 @@ class ReportNotificationTask(
           s"Sending a subscription notification email to ${emailAddress}"
         )
         mailService.send {
-          DgccrfReportNotification.build(
+          DgccrfReportNotification.EmailImpl(
             List(emailAddress),
             subscription,
             filteredReport.toList,

--- a/app/tasks/report/ReportNotificationTask.scala
+++ b/app/tasks/report/ReportNotificationTask.scala
@@ -15,7 +15,7 @@ import repositories.report.ReportRepositoryInterface
 import repositories.subscription.SubscriptionRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.emails.Email.DgccrfReportNotification
+import services.emails.EmailDefinitionsDggcrf.DgccrfReportNotification
 import services.emails.MailService
 import tasks.report.ReportNotificationTask.refineReportBasedOnSubscriptionFilters
 import tasks.ScheduledTask
@@ -91,7 +91,7 @@ class ReportNotificationTask(
           s"Sending a subscription notification email to ${emailAddress}"
         )
         mailService.send {
-          DgccrfReportNotification(
+          DgccrfReportNotification.build(
             List(emailAddress),
             subscription,
             filteredReport.toList,

--- a/app/tasks/report/ReportRemindersTask.scala
+++ b/app/tasks/report/ReportRemindersTask.scala
@@ -12,8 +12,8 @@ import play.api.Logger
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
-import services.emails.Email.ProReportsReadReminder
 import services.emails.Email.ProReportsUnreadReminder
+import services.emails.EmailDefinitionsPro.ProReportsReadReminder
 import services.emails.Email
 import services.emails.MailServiceInterface
 import tasks.ScheduledTask
@@ -21,16 +21,15 @@ import tasks.getTodayAtStartOfDayParis
 import utils.Constants.ActionEvent._
 import utils.Constants.EventType.SYSTEM
 import utils.EmailAddress
+import utils.Logs.RichLogger
 
 import java.time._
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Failure
 import scala.util.Success
-import utils.Logs.RichLogger
-
-import scala.concurrent.duration.FiniteDuration
 class ReportRemindersTask(
     actorSystem: ActorSystem,
     reportRepository: ReportRepositoryInterface,
@@ -97,7 +96,7 @@ class ReportRemindersTask(
               readByProsSent <- sendReminderEmailIfAtLeastOneReport(
                 readByPros,
                 users,
-                ProReportsReadReminder,
+                ProReportsReadReminder.EmailImpl,
                 EMAIL_PRO_REMIND_NO_ACTION
               )
               notReadByProsSent <- sendReminderEmailIfAtLeastOneReport(

--- a/app/tasks/report/ReportRemindersTask.scala
+++ b/app/tasks/report/ReportRemindersTask.scala
@@ -12,10 +12,10 @@ import play.api.Logger
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
-import services.Email.ProReportsReadReminder
-import services.Email.ProReportsUnreadReminder
-import services.Email
-import services.MailServiceInterface
+import services.emails.Email.ProReportsReadReminder
+import services.emails.Email.ProReportsUnreadReminder
+import services.emails.Email
+import services.emails.MailServiceInterface
 import tasks.ScheduledTask
 import tasks.getTodayAtStartOfDayParis
 import utils.Constants.ActionEvent._

--- a/app/tasks/report/ReportRemindersTask.scala
+++ b/app/tasks/report/ReportRemindersTask.scala
@@ -14,7 +14,7 @@ import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
 import services.emails.EmailDefinitionsPro.ProReportsReadReminder
 import services.emails.EmailDefinitionsPro.ProReportsUnreadReminder
-import services.emails.Email
+import services.emails.BaseEmail
 import services.emails.MailServiceInterface
 import tasks.ScheduledTask
 import tasks.getTodayAtStartOfDayParis
@@ -96,13 +96,13 @@ class ReportRemindersTask(
               readByProsSent <- sendReminderEmailIfAtLeastOneReport(
                 readByPros,
                 users,
-                ProReportsReadReminder.EmailImpl,
+                ProReportsReadReminder.Email,
                 EMAIL_PRO_REMIND_NO_ACTION
               )
               notReadByProsSent <- sendReminderEmailIfAtLeastOneReport(
                 notReadByPros,
                 users,
-                ProReportsUnreadReminder.EmailImpl,
+                ProReportsUnreadReminder.Email,
                 EMAIL_PRO_REMIND_NO_READING
               )
             } yield List(readByProsSent, notReadByProsSent).flatten
@@ -115,7 +115,7 @@ class ReportRemindersTask(
   private def sendReminderEmailIfAtLeastOneReport(
       reports: List[Report],
       users: List[User],
-      email: (List[EmailAddress], List[Report], Period) => Email,
+      email: (List[EmailAddress], List[Report], Period) => BaseEmail,
       action: ActionEventValue
   ): Future[Option[Either[List[UUID], List[UUID]]]] =
     if (reports.nonEmpty) {
@@ -155,7 +155,7 @@ class ReportRemindersTask(
   private def sendReminderEmail(
       reports: List[Report],
       users: List[User],
-      email: (List[EmailAddress], List[Report], Period) => Email,
+      email: (List[EmailAddress], List[Report], Period) => BaseEmail,
       action: ActionEventValue
   ): Future[Unit] = {
     val emailAddresses = users.map(_.email)

--- a/app/tasks/report/ReportRemindersTask.scala
+++ b/app/tasks/report/ReportRemindersTask.scala
@@ -12,8 +12,8 @@ import play.api.Logger
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.tasklock.TaskRepositoryInterface
-import services.emails.Email.ProReportsUnreadReminder
 import services.emails.EmailDefinitionsPro.ProReportsReadReminder
+import services.emails.EmailDefinitionsPro.ProReportsUnreadReminder
 import services.emails.Email
 import services.emails.MailServiceInterface
 import tasks.ScheduledTask
@@ -102,7 +102,7 @@ class ReportRemindersTask(
               notReadByProsSent <- sendReminderEmailIfAtLeastOneReport(
                 notReadByPros,
                 users,
-                ProReportsUnreadReminder,
+                ProReportsUnreadReminder.EmailImpl,
                 EMAIL_PRO_REMIND_NO_READING
               )
             } yield List(readByProsSent, notReadByProsSent).flatten

--- a/app/views/mails/dgccrf/reportDangerousProductNotification.scala.html
+++ b/app/views/mails/dgccrf/reportDangerousProductNotification.scala.html
@@ -77,7 +77,7 @@
         Pour consulter l'intégralité du signalement de produit dangereux, notamment les pièces jointes :
     </p>
     <ul>
-        <li>Vous devez suivre la procédure mentionner à l'instruction IN-2D-PIL-004</li>
+        <li>Vous devez suivre la procédure mentionnée à l'instruction IN-2D-PIL-004</li>
         <li>si vous possédez un compte sur SignalConso, connectez-vous sur <a href="@frontRoute.dashboard.login">@frontRoute.dashboard.login</a></li>
         <li>sinon, vous pouvez demander la création d'un compte en envoyant un mail avec vos nom, prénom et service à l'adresse <a href="mailto:@contactAddress">@contactAddress</a></li>
     </ul>

--- a/test/controllers/EmailValidationControllerSpec.scala
+++ b/test/controllers/EmailValidationControllerSpec.scala
@@ -18,7 +18,7 @@ import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test._
 import repositories.emailvalidation.EmailValidationRepositoryInterface
-import services.emails.Email.ConsumerValidateEmail
+import services.emails.EmailDefinitionsConsumer.ConsumerValidateEmail
 import services.emails.MailRetriesService.EmailRequest
 import utils.EmailAddress.EmptyEmailAddress
 import utils.AppSpec
@@ -26,8 +26,8 @@ import utils.EmailAddress
 import utils.Fixtures
 import utils.TestApp
 
-import java.time.temporal.ChronoUnit
 import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -167,7 +167,9 @@ class EmailValidationControllerSpec(implicit ee: ExecutionEnv)
         maybeEmailValidation.isDefined shouldEqual true
         maybeEmailValidation.flatMap(_.lastValidationDate) shouldEqual None
         val expectedEmail =
-          maybeEmailValidation.map(emailValidation => ConsumerValidateEmail(emailValidation, None, messagesApi))
+          maybeEmailValidation.map(emailValidation =>
+            ConsumerValidateEmail.EmailImpl(emailValidation, None, messagesApi)
+          )
         val emailSubject = expectedEmail.map(_.subject).get
         val emailBody    = expectedEmail.map(_.getBody(frontRoute, contactAddress)).get
         mailMustHaveBeenSent(Seq(unknownEmail), emailSubject, emailBody)
@@ -194,7 +196,9 @@ class EmailValidationControllerSpec(implicit ee: ExecutionEnv)
         maybeEmailValidation.isDefined shouldEqual true
         maybeEmailValidation.flatMap(_.lastValidationDate) shouldEqual None
         val expectedEmail =
-          maybeEmailValidation.map(emailValidation => ConsumerValidateEmail(emailValidation, None, messagesApi))
+          maybeEmailValidation.map(emailValidation =>
+            ConsumerValidateEmail.EmailImpl(emailValidation, None, messagesApi)
+          )
         val emailSubject = expectedEmail.map(_.subject).get
         val emailBody    = expectedEmail.map(_.getBody(frontRoute, contactAddress)).get
         mailMustHaveBeenSent(Seq(existingEmail), emailSubject, emailBody)
@@ -223,7 +227,9 @@ class EmailValidationControllerSpec(implicit ee: ExecutionEnv)
         maybeEmailValidation.isDefined shouldEqual true
         maybeEmailValidation.flatMap(_.lastValidationDate) shouldEqual Some(oldDate)
         val expectedEmail =
-          maybeEmailValidation.map(emailValidation => ConsumerValidateEmail(emailValidation, None, messagesApi))
+          maybeEmailValidation.map(emailValidation =>
+            ConsumerValidateEmail.EmailImpl(emailValidation, None, messagesApi)
+          )
         val emailSubject = expectedEmail.map(_.subject).get
         val emailBody    = expectedEmail.map(_.getBody(frontRoute, contactAddress)).get
         mailMustHaveBeenSent(Seq(existingEmail), emailSubject, emailBody)

--- a/test/controllers/EmailValidationControllerSpec.scala
+++ b/test/controllers/EmailValidationControllerSpec.scala
@@ -167,9 +167,7 @@ class EmailValidationControllerSpec(implicit ee: ExecutionEnv)
         maybeEmailValidation.isDefined shouldEqual true
         maybeEmailValidation.flatMap(_.lastValidationDate) shouldEqual None
         val expectedEmail =
-          maybeEmailValidation.map(emailValidation =>
-            ConsumerValidateEmail.EmailImpl(emailValidation, None, messagesApi)
-          )
+          maybeEmailValidation.map(emailValidation => ConsumerValidateEmail.Email(emailValidation, None, messagesApi))
         val emailSubject = expectedEmail.map(_.subject).get
         val emailBody    = expectedEmail.map(_.getBody(frontRoute, contactAddress)).get
         mailMustHaveBeenSent(Seq(unknownEmail), emailSubject, emailBody)
@@ -196,9 +194,7 @@ class EmailValidationControllerSpec(implicit ee: ExecutionEnv)
         maybeEmailValidation.isDefined shouldEqual true
         maybeEmailValidation.flatMap(_.lastValidationDate) shouldEqual None
         val expectedEmail =
-          maybeEmailValidation.map(emailValidation =>
-            ConsumerValidateEmail.EmailImpl(emailValidation, None, messagesApi)
-          )
+          maybeEmailValidation.map(emailValidation => ConsumerValidateEmail.Email(emailValidation, None, messagesApi))
         val emailSubject = expectedEmail.map(_.subject).get
         val emailBody    = expectedEmail.map(_.getBody(frontRoute, contactAddress)).get
         mailMustHaveBeenSent(Seq(existingEmail), emailSubject, emailBody)
@@ -227,9 +223,7 @@ class EmailValidationControllerSpec(implicit ee: ExecutionEnv)
         maybeEmailValidation.isDefined shouldEqual true
         maybeEmailValidation.flatMap(_.lastValidationDate) shouldEqual Some(oldDate)
         val expectedEmail =
-          maybeEmailValidation.map(emailValidation =>
-            ConsumerValidateEmail.EmailImpl(emailValidation, None, messagesApi)
-          )
+          maybeEmailValidation.map(emailValidation => ConsumerValidateEmail.Email(emailValidation, None, messagesApi))
         val emailSubject = expectedEmail.map(_.subject).get
         val emailBody    = expectedEmail.map(_.getBody(frontRoute, contactAddress)).get
         mailMustHaveBeenSent(Seq(existingEmail), emailSubject, emailBody)

--- a/test/controllers/EmailValidationControllerSpec.scala
+++ b/test/controllers/EmailValidationControllerSpec.scala
@@ -18,8 +18,8 @@ import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test._
 import repositories.emailvalidation.EmailValidationRepositoryInterface
-import services.Email.ConsumerValidateEmail
-import services.MailRetriesService.EmailRequest
+import services.emails.Email.ConsumerValidateEmail
+import services.emails.MailRetriesService.EmailRequest
 import utils.EmailAddress.EmptyEmailAddress
 import utils.AppSpec
 import utils.EmailAddress

--- a/test/controllers/report/CreateUpdateReportSpec.scala
+++ b/test/controllers/report/CreateUpdateReportSpec.scala
@@ -15,7 +15,7 @@ import play.api.libs.json.Json
 import play.api.libs.mailer.Attachment
 import play.api.test._
 import repositories.event.EventFilter
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
 import utils.Constants.ActionEvent.ActionEventValue
 import utils.Constants.ActionEvent
 import utils.Constants.Departments

--- a/test/controllers/report/GetReportSpec.scala
+++ b/test/controllers/report/GetReportSpec.scala
@@ -28,8 +28,8 @@ import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import repositories.reportfile.ReportFileRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.MailRetriesService
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService
 import utils.Constants.ActionEvent.ActionEventValue
 import utils.Constants.ActionEvent
 import utils.Constants.EventType

--- a/test/controllers/report/ReportResponseSpec.scala
+++ b/test/controllers/report/ReportResponseSpec.scala
@@ -16,7 +16,7 @@ import play.api.libs.mailer.Attachment
 import play.api.mvc.Result
 import play.api.test._
 import play.mvc.Http.Status
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
 import utils.Constants.ActionEvent
 import utils.Constants.ActionEvent.ActionEventValue
 import utils._

--- a/test/services/MailRetriesServiceSpec.scala
+++ b/test/services/MailRetriesServiceSpec.scala
@@ -1,5 +1,7 @@
 package services
 
+import services.emails.MailRetriesService
+
 import scala.concurrent.duration._
 
 class MailRetriesServiceSpec extends org.specs2.mutable.Specification {

--- a/test/services/MailServiceSpec.scala
+++ b/test/services/MailServiceSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.matcher.FutureMatchers
 import org.specs2.matcher.JsonMatchers
 import org.specs2.mutable.Specification
 import play.api.Logger
-import services.emails.Email.ProNewReportNotification
+import services.emails.EmailDefinitionsPro.ProNewReportNotification
 import services.emails.MailRetriesService
 import services.emails.MailService
 import services.emails.MailRetriesService.EmailRequest
@@ -113,7 +113,7 @@ class MailServiceSpecNoBlock(implicit ee: ExecutionEnv) extends BaseMailServiceS
 
     Await.result(
       mailService.send(
-        ProNewReportNotification(
+        ProNewReportNotification.build(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -150,7 +150,7 @@ class MailServiceSpecSomeBlock(implicit ee: ExecutionEnv) extends BaseMailServic
 
     Await.result(
       mailService.send(
-        ProNewReportNotification(
+        ProNewReportNotification.build(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -193,7 +193,7 @@ class MailServiceSpecAllBlock(implicit ee: ExecutionEnv) extends BaseMailService
 
     Await.result(
       mailService.send(
-        ProNewReportNotification(
+        ProNewReportNotification.build(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -237,7 +237,7 @@ class MailServiceSpecNotFilteredEmail(implicit ee: ExecutionEnv) extends BaseMai
 
     Await.result(
       mailService.send(
-        ProNewReportNotification(
+        ProNewReportNotification.build(
           NonEmptyList.fromListUnsafe(nonFilteredEmails ++ filteredEmail),
           reportForSubsidiary
         )
@@ -281,7 +281,7 @@ class MailServiceSpecFilteredEmail(implicit ee: ExecutionEnv) extends BaseMailSe
 
     Await.result(
       mailService.send(
-        ProNewReportNotification(
+        ProNewReportNotification.build(
           NonEmptyList.fromListUnsafe(nonFilteredEmails ++ filteredEmail),
           reportForSubsidiary
         )
@@ -316,14 +316,14 @@ class MailServiceSpecGroupForMaxRecipients(implicit ee: ExecutionEnv) extends Ba
       executionContext
     )
 
-    ProNewReportNotification(
+    ProNewReportNotification.build(
       NonEmptyList.of(EmailAddress(s"1@email.fr"), EmailAddress(s"2@email.fr")),
       reportForSubsidiary
     )
 
     Await.result(
       mailService.send(
-        ProNewReportNotification(
+        ProNewReportNotification.build(
           NonEmptyList.fromListUnsafe(recipients),
           reportForSubsidiary
         )

--- a/test/services/MailServiceSpec.scala
+++ b/test/services/MailServiceSpec.scala
@@ -113,7 +113,7 @@ class MailServiceSpecNoBlock(implicit ee: ExecutionEnv) extends BaseMailServiceS
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.EmailImpl(
+        ProNewReportNotification.Email(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -150,7 +150,7 @@ class MailServiceSpecSomeBlock(implicit ee: ExecutionEnv) extends BaseMailServic
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.EmailImpl(
+        ProNewReportNotification.Email(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -193,7 +193,7 @@ class MailServiceSpecAllBlock(implicit ee: ExecutionEnv) extends BaseMailService
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.EmailImpl(
+        ProNewReportNotification.Email(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -237,7 +237,7 @@ class MailServiceSpecNotFilteredEmail(implicit ee: ExecutionEnv) extends BaseMai
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.EmailImpl(
+        ProNewReportNotification.Email(
           NonEmptyList.fromListUnsafe(nonFilteredEmails ++ filteredEmail),
           reportForSubsidiary
         )
@@ -281,7 +281,7 @@ class MailServiceSpecFilteredEmail(implicit ee: ExecutionEnv) extends BaseMailSe
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.EmailImpl(
+        ProNewReportNotification.Email(
           NonEmptyList.fromListUnsafe(nonFilteredEmails ++ filteredEmail),
           reportForSubsidiary
         )
@@ -316,14 +316,14 @@ class MailServiceSpecGroupForMaxRecipients(implicit ee: ExecutionEnv) extends Ba
       executionContext
     )
 
-    ProNewReportNotification.EmailImpl(
+    ProNewReportNotification.Email(
       NonEmptyList.of(EmailAddress(s"1@email.fr"), EmailAddress(s"2@email.fr")),
       reportForSubsidiary
     )
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.EmailImpl(
+        ProNewReportNotification.Email(
           NonEmptyList.fromListUnsafe(recipients),
           reportForSubsidiary
         )

--- a/test/services/MailServiceSpec.scala
+++ b/test/services/MailServiceSpec.scala
@@ -113,7 +113,7 @@ class MailServiceSpecNoBlock(implicit ee: ExecutionEnv) extends BaseMailServiceS
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.build(
+        ProNewReportNotification.EmailImpl(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -150,7 +150,7 @@ class MailServiceSpecSomeBlock(implicit ee: ExecutionEnv) extends BaseMailServic
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.build(
+        ProNewReportNotification.EmailImpl(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -193,7 +193,7 @@ class MailServiceSpecAllBlock(implicit ee: ExecutionEnv) extends BaseMailService
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.build(
+        ProNewReportNotification.EmailImpl(
           NonEmptyList.of(proWithAccessToHeadOffice.email, proWithAccessToSubsidiary.email),
           reportForSubsidiary
         )
@@ -237,7 +237,7 @@ class MailServiceSpecNotFilteredEmail(implicit ee: ExecutionEnv) extends BaseMai
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.build(
+        ProNewReportNotification.EmailImpl(
           NonEmptyList.fromListUnsafe(nonFilteredEmails ++ filteredEmail),
           reportForSubsidiary
         )
@@ -281,7 +281,7 @@ class MailServiceSpecFilteredEmail(implicit ee: ExecutionEnv) extends BaseMailSe
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.build(
+        ProNewReportNotification.EmailImpl(
           NonEmptyList.fromListUnsafe(nonFilteredEmails ++ filteredEmail),
           reportForSubsidiary
         )
@@ -316,14 +316,14 @@ class MailServiceSpecGroupForMaxRecipients(implicit ee: ExecutionEnv) extends Ba
       executionContext
     )
 
-    ProNewReportNotification.build(
+    ProNewReportNotification.EmailImpl(
       NonEmptyList.of(EmailAddress(s"1@email.fr"), EmailAddress(s"2@email.fr")),
       reportForSubsidiary
     )
 
     Await.result(
       mailService.send(
-        ProNewReportNotification.build(
+        ProNewReportNotification.EmailImpl(
           NonEmptyList.fromListUnsafe(recipients),
           reportForSubsidiary
         )

--- a/test/services/MailServiceSpec.scala
+++ b/test/services/MailServiceSpec.scala
@@ -7,8 +7,10 @@ import org.specs2.matcher.FutureMatchers
 import org.specs2.matcher.JsonMatchers
 import org.specs2.mutable.Specification
 import play.api.Logger
-import services.Email.ProNewReportNotification
-import services.MailRetriesService.EmailRequest
+import services.emails.Email.ProNewReportNotification
+import services.emails.MailRetriesService
+import services.emails.MailService
+import services.emails.MailRetriesService.EmailRequest
 import utils._
 
 import java.util.UUID

--- a/test/tasks/account/InactiveDgccrfAccountReminderTaskSpec.scala
+++ b/test/tasks/account/InactiveDgccrfAccountReminderTaskSpec.scala
@@ -12,8 +12,8 @@ import play.api.libs.json.Json
 import play.api.mvc.Results
 import repositories.event.EventRepositoryInterface
 import repositories.user.UserRepositoryInterface
-import services.MailRetriesService
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService
 import utils.AppSpec
 import utils.Constants.ActionEvent
 import utils.Constants.EventType

--- a/test/tasks/report/DailyReportNotificationTaskSpec.scala
+++ b/test/tasks/report/DailyReportNotificationTaskSpec.scala
@@ -7,7 +7,7 @@ import models.report.ReportTag
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
 import utils._
 
 import java.time.OffsetDateTime

--- a/test/tasks/report/NoReportNotificationTaskSpec.scala
+++ b/test/tasks/report/NoReportNotificationTaskSpec.scala
@@ -7,7 +7,7 @@ import models.report.ReportTag
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
 import utils._
 
 import java.time.OffsetDateTime

--- a/test/tasks/report/ReportRemindersTaskUnitSpec.scala
+++ b/test/tasks/report/ReportRemindersTaskUnitSpec.scala
@@ -19,8 +19,8 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
-import services.Email
-import services.MailServiceInterface
+import services.emails.Email
+import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent.EMAIL_PRO_NEW_REPORT
 import utils.Constants.ActionEvent.EMAIL_PRO_REMIND_NO_READING
 import utils.Constants.EventType

--- a/test/tasks/report/ReportRemindersTaskUnitSpec.scala
+++ b/test/tasks/report/ReportRemindersTaskUnitSpec.scala
@@ -113,14 +113,14 @@ class ReportRemindersTaskUnitSpec extends Specification with FutureMatchers {
 
       when(
         mailService.send(
-          ProReportsUnreadReminder.EmailImpl(List(proUser1.email), List(report1, report2), Period.ofDays(7))
+          ProReportsUnreadReminder.Email(List(proUser1.email), List(report1, report2), Period.ofDays(7))
         )
       ).thenReturn(Future.unit)
-      when(mailService.send(ProReportsUnreadReminder.EmailImpl(List(proUser1.email), List(report4), Period.ofDays(7))))
+      when(mailService.send(ProReportsUnreadReminder.Email(List(proUser1.email), List(report4), Period.ofDays(7))))
         .thenReturn(Future.unit)
       when(
         mailService.send(
-          ProReportsReadReminder.EmailImpl(List(proUser1.email), List(report5, report6), Period.ofDays(7))
+          ProReportsReadReminder.Email(List(proUser1.email), List(report5, report6), Period.ofDays(7))
         )
       ).thenReturn(Future.unit)
 

--- a/test/tasks/report/ReportRemindersTaskUnitSpec.scala
+++ b/test/tasks/report/ReportRemindersTaskUnitSpec.scala
@@ -21,7 +21,6 @@ import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import services.emails.EmailDefinitionsPro.ProReportsReadReminder
 import services.emails.EmailDefinitionsPro.ProReportsUnreadReminder
-import services.emails.Email
 import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent.EMAIL_PRO_NEW_REPORT
 import utils.Constants.ActionEvent.EMAIL_PRO_REMIND_NO_READING

--- a/test/tasks/report/ReportRemindersTaskUnitSpec.scala
+++ b/test/tasks/report/ReportRemindersTaskUnitSpec.scala
@@ -20,6 +20,7 @@ import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
 import services.emails.EmailDefinitionsPro.ProReportsReadReminder
+import services.emails.EmailDefinitionsPro.ProReportsUnreadReminder
 import services.emails.Email
 import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent.EMAIL_PRO_NEW_REPORT
@@ -112,9 +113,11 @@ class ReportRemindersTaskUnitSpec extends Specification with FutureMatchers {
         .thenReturn(Future.successful(Map(report3.id -> List(event3), report7.id -> List(event7))))
 
       when(
-        mailService.send(Email.ProReportsUnreadReminder(List(proUser1.email), List(report1, report2), Period.ofDays(7)))
+        mailService.send(
+          ProReportsUnreadReminder.EmailImpl(List(proUser1.email), List(report1, report2), Period.ofDays(7))
+        )
       ).thenReturn(Future.unit)
-      when(mailService.send(Email.ProReportsUnreadReminder(List(proUser1.email), List(report4), Period.ofDays(7))))
+      when(mailService.send(ProReportsUnreadReminder.EmailImpl(List(proUser1.email), List(report4), Period.ofDays(7))))
         .thenReturn(Future.unit)
       when(
         mailService.send(

--- a/test/tasks/report/ReportRemindersTaskUnitSpec.scala
+++ b/test/tasks/report/ReportRemindersTaskUnitSpec.scala
@@ -8,9 +8,9 @@ import models.company.AccessLevel
 import models.event.Event
 import models.report.ReportStatus
 import orchestrators.CompaniesVisibilityOrchestrator
-import org.mockito.Mockito.when
 import org.mockito.ArgumentMatchers.argThat
 import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito.when
 import org.specs2.matcher.FutureMatchers
 import org.specs2.mock.Mockito.any
 import org.specs2.mock.Mockito.mock
@@ -19,6 +19,7 @@ import repositories.company.CompanyRepositoryInterface
 import repositories.companyaccess.CompanyAccessRepositoryInterface
 import repositories.event.EventRepositoryInterface
 import repositories.report.ReportRepositoryInterface
+import services.emails.EmailDefinitionsPro.ProReportsReadReminder
 import services.emails.Email
 import services.emails.MailServiceInterface
 import utils.Constants.ActionEvent.EMAIL_PRO_NEW_REPORT
@@ -31,9 +32,9 @@ import utils.TaskRepositoryMock
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Period
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 
 class ReportRemindersTaskUnitSpec extends Specification with FutureMatchers {
@@ -116,7 +117,9 @@ class ReportRemindersTaskUnitSpec extends Specification with FutureMatchers {
       when(mailService.send(Email.ProReportsUnreadReminder(List(proUser1.email), List(report4), Period.ofDays(7))))
         .thenReturn(Future.unit)
       when(
-        mailService.send(Email.ProReportsReadReminder(List(proUser1.email), List(report5, report6), Period.ofDays(7)))
+        mailService.send(
+          ProReportsReadReminder.EmailImpl(List(proUser1.email), List(report5, report6), Period.ofDays(7))
+        )
       ).thenReturn(Future.unit)
 
       when(eventRepository.create(argMatching[Event] { case Event(_, Some(report1.id), _, _, _, _, _, _) => }))

--- a/test/tasks/report/ReportTagFilterNotificationTaskSpec.scala
+++ b/test/tasks/report/ReportTagFilterNotificationTaskSpec.scala
@@ -6,7 +6,7 @@ import models.report.ReportTag
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
 import utils._
 
 import java.time.OffsetDateTime

--- a/test/tasks/report/WeeklyReportNotificationTaskSpec.scala
+++ b/test/tasks/report/WeeklyReportNotificationTaskSpec.scala
@@ -5,7 +5,7 @@ import models.company.Address
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
 import utils._
 
 import java.time.OffsetDateTime

--- a/test/utils/AppSpec.scala
+++ b/test/utils/AppSpec.scala
@@ -23,8 +23,8 @@ import pureconfig.ConfigSource
 import pureconfig.configurable.localTimeConfigConvert
 import pureconfig.generic.auto._
 import pureconfig.generic.semiauto.deriveReader
-import services.MailRetriesService
-import services.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService.EmailRequest
+import services.emails.MailRetriesService
 import tasks.company.CompanySyncServiceInterface
 
 import java.io.File


### PR DESCRIPTION
Wrap each Email case class in a EmailDefinitions object, to force us to always declare email examples for the admin tests tools